### PR TITLE
Add function to rebuild CBZ archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ log.txt
 *.log
 .bandit
 quick.py
+missing_stubs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,10 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
+  # - repo: https://github.com/psf/black
+  #   rev: 25.1.0
+  #   hooks:
+  #     - id: black
 
   - repo: local
     hooks:

--- a/metadata_controller.py
+++ b/metadata_controller.py
@@ -1,12 +1,12 @@
+import calendar
 import logging
 import os
+import re
 import shutil
 import sqlite3
 import zipfile
 from pathlib import Path
 from typing import Optional
-import re
-import calendar
 
 from defusedxml import ElementTree as ET
 from dotenv import load_dotenv
@@ -94,7 +94,7 @@ class MetadataController:
         santised = re.sub(r'[<>:"/\\|?*]', "-", filename)
         santised = santised.rstrip(" .")
         return santised
-    
+
     def reformat(self) -> None:
         """
         Converts .cbr files into .cbz files.
@@ -197,7 +197,7 @@ class MetadataController:
         """
         self.reformat()
         has_metadata = self.has_metadata()
-        
+
         if has_metadata:
             raw_comic_metadata: ComicInfo = self.get_embedded_metadata()
         else:
@@ -215,11 +215,15 @@ class MetadataController:
                 # Need to remove ComicInfo.xml and
                 # wait until sufficient data is supplied.
                 raise ValueError(f"Missing required {key} field.")
-            
+
         new_name, publisher_int = self.create_name(clean_comic_metadata)
 
         inserter = MetadataInserter(clean_comic_metadata, self.filepath)
-        inserter.insert_xml()
+        if inserter.create_valid_struc():
+            inserter.run_inserter()
+        else:
+            raise ValueError("Missing required required fields in metadata.")
+
         self.insert_into_db(clean_comic_metadata)
         self.extract_cover()
         self.move_to_publisher_folder(new_name, publisher_int)
@@ -227,12 +231,10 @@ class MetadataController:
         # This all needs to be split up into modular components so the different aspects, db insertion, cover extracting
         # are independent and use the same data types to ensure consistency.
 
-        # if self.has_metadata():
-        #     self.process_with_metadata()
-        #     return
-
     def create_name(self, clean_metadata: ComicInfo) -> tuple[str, int]:
-        date_suffix = f"{calendar.month_abbr[clean_metadata.month]} {clean_metadata.year}"  # type: ignore
+        date_suffix = (
+            f"{calendar.month_abbr[clean_metadata.month]} {clean_metadata.year}"  # type: ignore
+        )
         volume_num = clean_metadata.volume_num
         collection_id = clean_metadata.collection_type
         collection_name = ""
@@ -351,7 +353,7 @@ class MetadataController:
             inputter.run()
             flat_data = inputter.flatten_data()
         except Exception as e:
-            raise ValueError(f"[Error] {e}")
+            raise ValueError(f"[Error] {e}") from e
         insert_into_fts5(flat_data)
         logging.info("Success! Added all data to the database")
         self.inputter = inputter

--- a/metadata_controller.py
+++ b/metadata_controller.py
@@ -222,7 +222,7 @@ class MetadataController:
         if inserter.create_valid_struc():
             inserter.run_inserter()
         else:
-            raise ValueError("Missing required required fields in metadata.")
+            raise ValueError("Missing required fields in metadata.")
 
         self.insert_into_db(clean_comic_metadata)
         self.extract_cover()

--- a/metadata_inserter.py
+++ b/metadata_inserter.py
@@ -139,8 +139,10 @@ class MetadataInserter:
     def replace_xml(self, xml_bytes: bytes) -> None:
         temp_path = self.path.with_suffix(".tmp")
         try:
-            with zipfile.ZipFile(self.path, "r") as zin, \
-            zipfile.ZipFile(temp_path, "w", zipfile.ZIP_DEFLATED) as zout:
+            with (
+                zipfile.ZipFile(self.path, "r") as zin,
+                zipfile.ZipFile(temp_path, "w", zipfile.ZIP_DEFLATED) as zout,
+            ):
                 for item in zin.infolist():
                     if item.filename != "ComicInfo.xml":
                         zout.writestr(item, zin.read(item.filename))

--- a/metadata_inserter.py
+++ b/metadata_inserter.py
@@ -52,7 +52,7 @@ class MetadataInserter:
             update=self.creators_parsing(self.info.creators or [])
         )
         self.information = self.fill_gaps(information)
-        return self.pending
+        return not self.pending
 
     def create_xml(self) -> bytes:
         root = ET.Element("ComicInfo")
@@ -66,16 +66,13 @@ class MetadataInserter:
         tree.write(xml_bytes, encoding="utf-8", xml_declaration=True)
         return xml_bytes.getvalue()
 
-    def insert_xml(self, xml_bytes: bytes):
+    def insert_xml(self, xml_bytes: bytes) -> None:
         with zipfile.ZipFile(self.path, "a") as cbz:
             cbz.writestr("ComicInfo.xml", xml_bytes)
 
     def already_has_xml(self) -> bool:
         with zipfile.ZipFile(self.path, "r") as cbz:
-            if "ComicInfo.xml" in cbz.namelist():
-                return True
-            else:
-                return False
+            return "ComicInfo.xml" in cbz.namelist()
 
     @staticmethod
     def creators_parsing(creators: list[tuple[str, str]]) -> dict[str, str]:
@@ -141,14 +138,19 @@ class MetadataInserter:
 
     def replace_xml(self, xml_bytes: bytes) -> None:
         temp_path = self.path.with_suffix(".tmp")
-        with zipfile.ZipFile(self.path, "r") as zin:
-            with zipfile.ZipFile(temp_path, "w") as zout:
+        try:
+            with zipfile.ZipFile(self.path, "r") as zin, \
+            zipfile.ZipFile(temp_path, "w", zipfile.ZIP_DEFLATED) as zout:
                 for item in zin.infolist():
                     if item.filename != "ComicInfo.xml":
                         zout.writestr(item, zin.read(item.filename))
                 zout.writestr("ComicInfo.xml", xml_bytes)
 
-        os.replace(temp_path, self.path)
+            os.replace(temp_path, self.path)
+        except Exception:
+            if temp_path.exists():
+                temp_path.unlink(missing_ok=True)
+            raise
 
     def run_inserter(self) -> None:
         xml = self.create_xml()

--- a/metadata_inserter.py
+++ b/metadata_inserter.py
@@ -1,3 +1,4 @@
+import os
 import xml.etree.ElementTree as ET  # nosec
 import zipfile
 from io import BytesIO
@@ -32,8 +33,9 @@ class MetadataInserter:
     def __init__(self, clean_info: ComicInfo, filepath: Path):
         self.info = clean_info
         self.path = filepath
+        self.pending = False
 
-    def insert_xml(self):
+    def create_valid_struc(self) -> bool:
         information = XMLStruc(
             Title=self.info.title or "",
             Series=self.info.series or "",
@@ -49,35 +51,31 @@ class MetadataInserter:
         information = information.model_copy(
             update=self.creators_parsing(self.info.creators or [])
         )
-        information = self.fill_gaps(information)
+        self.information = self.fill_gaps(information)
+        return self.pending
 
+    def create_xml(self) -> bytes:
         root = ET.Element("ComicInfo")
 
-        for key, value in information.model_dump().items():
+        for key, value in self.information.model_dump().items():
             child = ET.SubElement(root, key)
             child.text = str(value)
 
         xml_bytes = BytesIO()
         tree = ET.ElementTree(root)
         tree.write(xml_bytes, encoding="utf-8", xml_declaration=True)
+        return xml_bytes.getvalue()
 
-        if self.has_complete_xml(xml_bytes.getvalue()):
-            return
-
+    def insert_xml(self, xml_bytes: bytes):
         with zipfile.ZipFile(self.path, "a") as cbz:
-            cbz.writestr("ComicInfo.xml", xml_bytes.getvalue())
+            cbz.writestr("ComicInfo.xml", xml_bytes)
 
-    def has_complete_xml(self, xml_bytes: bytes) -> bool:
+    def already_has_xml(self) -> bool:
         with zipfile.ZipFile(self.path, "r") as cbz:
             if "ComicInfo.xml" in cbz.namelist():
-                content = cbz.read("ComicInfo.xml")
-                return self.xml_equal(content, xml_bytes)
+                return True
             else:
                 return False
-
-    @staticmethod
-    def xml_equal(a: bytes, b: bytes) -> bool:
-        return ET.tostring(ET.fromstring(a)) == ET.tostring(ET.fromstring(b))
 
     @staticmethod
     def creators_parsing(creators: list[tuple[str, str]]) -> dict[str, str]:
@@ -118,8 +116,7 @@ class MetadataInserter:
 
         return creator_dict
 
-    @staticmethod
-    def fill_gaps(comic_info: XMLStruc) -> XMLStruc:
+    def fill_gaps(self, comic_info: XMLStruc) -> XMLStruc:
         MANDATORY_FIELDS = {
             "Writer",
             "Penciller",
@@ -135,8 +132,28 @@ class MetadataInserter:
         for field in MANDATORY_FIELDS:
             if field not in data or not data[field]:
                 data[field] = "PENDING"
+                self.pending = True
         for key in list(data.keys()):
             if key not in MANDATORY_FIELDS and not data[key]:
                 data[key] = "MISSING"
 
         return comic_info.model_copy(update=data)
+
+    def replace_xml(self, xml_bytes: bytes) -> None:
+        temp_path = self.path.with_suffix(".tmp")
+        with zipfile.ZipFile(self.path, "r") as zin:
+            with zipfile.ZipFile(temp_path, "w") as zout:
+                for item in zin.infolist():
+                    if item.filename != "ComicInfo.xml":
+                        zout.writestr(item, zin.read(item.filename))
+                zout.writestr("ComicInfo.xml", xml_bytes)
+
+        os.replace(temp_path, self.path)
+
+    def run_inserter(self) -> None:
+        xml = self.create_xml()
+
+        if self.already_has_xml():
+            self.replace_xml(xml)
+        else:
+            self.insert_xml(xml)


### PR DESCRIPTION
This replaces the previous method where the .xml files were just appended into the archive. If a file is processed more than once this could lead to errors because of stale data that the code believes is the most up to date.

It is safe to delete the old .xml since the function is only called once the .xml has sufficient data and the tagging process has been completed (i.e. the required fields are not empty).

closes #51 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added metadata validation with clearer error messages for missing fields.
  * Improved reliability of metadata file operations via atomic writes to prevent partial updates.

* **Chores**
  * Updated repository ignore rules.
  * Adjusted development tooling configuration (formatter hook disabled in pre‑commit).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->