### PR TITLE
Refactor ComicGridView

### DIFF
--- a/comic_grid_view.py
+++ b/comic_grid_view.py
@@ -356,6 +356,7 @@ class ComicGridView(QWidget):
         self.grid = ComicGrid(
             self.comics, self.cont, collection_names, collection_ids, colums
         )
+        self.grid.metadata_requested.connect(self.metadata_requested.emit)
 
         self.scroll_area = QScrollArea()
         self.scroll_area.setWidgetResizable(True)

--- a/comic_grid_view.py
+++ b/comic_grid_view.py
@@ -1,10 +1,13 @@
-from PySide6.QtCore import QMimeData, QSize, Qt, Signal
+from PySide6.QtCore import QEvent, QMimeData, QObject, QSize, Qt, Signal
 from PySide6.QtGui import QDrag, QIcon
 from PySide6.QtWidgets import (
     QGridLayout,
+    QHBoxLayout,
     QListWidget,
     QListWidgetItem,
+    QPushButton,
     QScrollArea,
+    QSplitter,
     QVBoxLayout,
     QWidget,
 )
@@ -24,24 +27,48 @@ class ComicGridView(QWidget):
         comics: list[GUIComicInfo],
         reading_controller: ReadingController,
         colums: int = 5,
+        collection: bool = False,
     ):
         super().__init__()
-
+        self.collection = collection
+        self.comics = comics
         self.cont = reading_controller
         with RepoWorker() as repo_worker:
             collection_names, collection_ids = repo_worker.get_collections()
         self.context_menu = GridViewContextMenuManager(collection_ids, collection_names)
-        self.comic_widgets = []
-        layout = QVBoxLayout()
+        self.comic_widgets: list[GeneralComicWidget] = []
 
-        grid_widget = QWidget()
-        grid_layout = QGridLayout(grid_widget)
-        grid_widget.setLayout(grid_layout)
-        grid_layout.setSpacing(10)
-        grid_layout.setContentsMargins(10, 10, 10, 10)
+        basic_layout = QVBoxLayout()
+
+        self.scroll_area = self.create_scroll_area(colums)
+        self.scroll_area.viewport().installEventFilter(self)
+
+        basic_layout.addWidget(self.scroll_area)
+        if collection:
+            col_layout = QVBoxLayout()
+            self.splitter = QSplitter()
+            self.add_to_collection_button = QPushButton("Add..")
+            self.add_to_collection_button.clicked.connect(self.comic_explore_window)
+            col_layout.addWidget(self.scroll_area)
+            col_layout.addWidget(self.add_to_collection_button)
+            self.collection_content = QWidget()
+            self.collection_content.setLayout(col_layout)
+            self.splitter.addWidget(self.collection_content)
+            fin_layout = QHBoxLayout()
+            fin_layout.addWidget(self.splitter)
+            self.setLayout(fin_layout)
+        else:
+            self.setLayout(basic_layout)
+
+    def create_scroll_area(self, columns) -> QScrollArea:
+        self.grid_widget = QWidget()
+        self.grid_layout = QGridLayout(self.grid_widget)
+        self.grid_widget.setLayout(self.grid_layout)
+        self.grid_layout.setSpacing(10)
+        self.grid_layout.setContentsMargins(10, 10, 10, 10)
 
         row = col = 0
-        for comic in comics:
+        for comic in self.comics:
             comic_widget = GeneralComicWidget(
                 comic,
                 single_left_click=self.metadata_panel,
@@ -50,7 +77,7 @@ class ComicGridView(QWidget):
                 size=(180, 270),
             )
             self.comic_widgets.append(comic_widget)
-            grid_layout.addWidget(
+            self.grid_layout.addWidget(
                 comic_widget,
                 row,
                 col,
@@ -58,22 +85,51 @@ class ComicGridView(QWidget):
             )
 
             col += 1
-            if col >= colums:
+            if col >= columns:
                 col = 0
                 row += 1
 
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
-        scroll_area.setWidget(grid_widget)
-
-        layout.addWidget(scroll_area)
-        self.setLayout(layout)
+        scroll_area.setWidget(self.grid_widget)
+        return scroll_area
 
     def open_reader(self, comic_info: GUIComicInfo):
         self.cont.read_comic(comic_info)
 
     def metadata_panel(self, comic_info: GUIComicInfo):
         self.metadata_requested.emit(comic_info)
+
+    def comic_explore_window(self):
+        with RepoWorker() as repo_worker:
+            comics = repo_worker.get_all_comics(thumb=True)
+        self.all_comics = DraggableComicGridView(comics)
+        self.splitter.addWidget(self.all_comics)
+
+    def relayout_grid(self):
+        width = self.scroll_area.viewport().width()
+        item_width = 180 + 10
+        columns = max(1, width // item_width)
+
+        while self.grid_layout.count():
+            self.grid_layout.takeAt(0)
+
+        row = col = 0
+        for widget in self.comic_widgets:
+            self.grid_layout.addWidget(widget, row, col)
+            col += 1
+            if col >= columns:
+                col = 0
+                row += 1
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        if (
+            watched == self.scroll_area.viewport()
+            and event.type() == QEvent.Type.Resize
+        ):
+            if self.collection:
+                self.relayout_grid()
+        return super().eventFilter(watched, event)
 
 
 class DraggableComicGridView(QListWidget):

--- a/comic_grid_view.py
+++ b/comic_grid_view.py
@@ -20,6 +20,10 @@ from right_click_menus import GridViewContextMenuManager
 
 
 class ComicGrid(QWidget):
+    """
+    A class to create a grid of widgets, the grid itself is QWidget.
+    """
+
     metadata_requested = Signal(GUIComicInfo)
 
     def __init__(
@@ -30,6 +34,22 @@ class ComicGrid(QWidget):
         coll_ids: list[int],
         colums: int = 5,
     ):
+        """
+        Generates the grid of comics from an inital list of comic information. Adds
+        different behaviours of the individual comic widgets on different clicks.
+
+        Args:
+            comics (list[GUIComicInfo]): The initial list of comic information to
+            construct the grid from.
+            reading_controller (ReadingController): The reading controller which
+            allows the user to easily read the comic via a double left-click.
+            coll_names (list[str]): The list of all collection names, needed for
+            the right-click context menu.
+            coll_ids (list[int]): The list of all collection ids, needed for the
+            right-click context menu.
+            colums (int, optional): The number of columns to arrange the comic
+            widgets into. Defaults to 5.
+        """
         super().__init__()
         self.comics = comics
         self.cont = reading_controller
@@ -64,7 +84,15 @@ class ComicGrid(QWidget):
                 row += 1
 
     def add_comics(self, comics: list[GUIComicInfo]):
-        start_index = len(self.comics)
+        """
+        Adds comics to the grid by figuring out which row or column to place
+        them in.
+
+        Args:
+            comics (list[GUIComicInfo]): The list of comic information that needs
+                to be added to the grid.
+        """
+        start_index = len(self.comic_widgets)
         for i, comic in enumerate(comics):
             comic_widget = GeneralComicWidget(
                 comic,
@@ -84,12 +112,33 @@ class ComicGrid(QWidget):
             )
 
     def open_reader(self, comic_info: GUIComicInfo):
+        """
+        Uses the passed in reading controller to open the comic with the reader.
+
+        Args:
+            comic_info (GUIComicInfo): The information of the comic to be read.
+        """
         self.cont.read_comic(comic_info)
 
     def metadata_panel(self, comic_info: GUIComicInfo):
+        """
+        Opens a metadata panel on the rhs containing detailed information about
+        the clicked comic.
+
+        Args:
+            comic_info (GUIComicInfo): The information of the comic that extended
+                metedata must be fetched for.
+        """
         self.metadata_requested.emit(comic_info)
 
     def relayout_grid(self, columns: int):
+        """
+        Rearranges the items in the grid to a certain amount of columns.
+
+        Args:
+            columns (int): The number of columns to arrange the grid items
+                into.
+        """
         self.columns = columns
         while self.grid_layout.count():
             item = self.grid_layout.takeAt(0)
@@ -109,6 +158,11 @@ class ComicGrid(QWidget):
 
 
 class ComicCollectionGridView(QWidget):
+    """
+    A class to create a grid of widgets representing the contents
+    of a comic collection. Has type QWidget.
+    """
+
     def __init__(
         self,
         comics: list[GUIComicInfo],
@@ -116,11 +170,25 @@ class ComicCollectionGridView(QWidget):
         collection_id: int,
         columns: int = 5,
     ):
+        """
+        Creates a grid of comics in a collection, allows drag actions to happen
+        so the user can easily add comics to the collection.
+
+        Args:
+            comics (list[GUIComicInfo]): The list of comics to initially create the
+            grid with.
+            reading_controller (ReadingController): The application-wide reading
+            controller.
+            collection_id (int): The id of the specific collection the grid is showing.
+            columns (int, optional): The number of columns to originally display the
+            comic widgets with. Defaults to 5.
+        """
         super().__init__()
         self.coll_id = collection_id
         self.col = columns
         self.comics = comics
         self.cont = reading_controller
+        self.explore = False
         with RepoWorker() as repo_worker:
             collection_names, collection_ids = repo_worker.get_collections()
         self.context_menu = GridViewContextMenuManager(collection_ids, collection_names)
@@ -153,18 +221,39 @@ class ComicCollectionGridView(QWidget):
         self.setLayout(fin_layout)
 
     def comic_explore_window(self):
-        with RepoWorker() as repo_worker:
-            comics = repo_worker.get_all_comics(thumb=True)
-        self.all_comics = DraggableComicGridView(comics)
-        self.splitter.addWidget(self.all_comics)
+        """
+        Opens a window on the rhs containing all the comics in the database, of which the
+        user can drag to move comics into the collection in the left-hand panel.
+
+        If the explore panel is already open, clicking the button closes it and
+        vice-versa.
+        """
+        if not self.explore:
+            with RepoWorker() as repo_worker:
+                comics = repo_worker.get_all_comics(thumb=True)
+            self.all_comics = DraggableComicGridView(comics)
+            self.splitter.addWidget(self.all_comics)
+            self.explore = True
+        else:
+            self.all_comics.setParent(None)
+            self.all_comics.deleteLater()
+            self.explore = False
 
     def relayout_grid(self):
+        """
+        Triggered upon a resizing of the grid. Calculates the new number of columns
+        given the new width of the comic grid widget.
+        """
         width = self.scroll_area.viewport().width()
         item_width = 180 + 10
         columns = max(1, width // item_width)
         self.grid.relayout_grid(columns)
 
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        """
+        Watches for events and checks that they are resizing evenets. If so,
+        calls the resizing function.
+        """
         if (
             watched == self.scroll_area.viewport()
             and event.type() == QEvent.Type.Resize
@@ -173,18 +262,31 @@ class ComicCollectionGridView(QWidget):
         return super().eventFilter(watched, event)
 
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
+        """
+        Watches for drag events to enter the frame of the widget, allows it to
+        continue if the MIME data comes from the DraggableComicGridView.
+        """
         if event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
             event.acceptProposedAction()
         else:
             event.ignore()
 
     def dragMoveEvent(self, event: QDragMoveEvent) -> None:
+        """
+        Watches for drag events moving across the widget,allows it to continue
+        if the MIME data comes from the DraggableComicGridView.
+        """
         if event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
             event.acceptProposedAction()
         else:
             event.ignore()
 
     def dropEvent(self, event: QDropEvent) -> None:
+        """
+        Watches for drop events in this widget. If the MIME data comes from the
+        DraggableComicGridView, then it decodes the information and passes it to
+        the handler.
+        """
         if event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
             data = event.mimeData().data(DraggableComicGridView.MIME_TYPE)
 
@@ -197,16 +299,34 @@ class ComicCollectionGridView(QWidget):
             event.ignore()
 
     def handle_dropped_comic(self, ids: list[str]):
+        """
+        Handles comics being dropped into the collection; ensures duplicates
+        are ignored, adds the remainder to the database and updates the UI
+        to display the changes.
+
+        Args:
+            ids (list[str]): The list of comic ids that were dragged into the widget.
+        """
+        existing_ids = {comic.primary_id for comic in self.comics}
+        ids_to_add = [i for i in ids if i not in existing_ids]
+        if not ids_to_add:
+            return
+
         with RepoWorker() as worker:
-            for i in ids:
+            for i in ids_to_add:
                 worker.add_to_collection(self.coll_id, i)
-            updated = worker.create_basemodel(ids)
+            updated = worker.create_basemodel(ids_to_add)
 
         self.comics.extend(updated)
         self.grid.add_comics(updated)
 
 
 class ComicGridView(QWidget):
+    """
+    A class to represent a grid of comics with no additional, special
+    functionality. Has type QWidget.
+    """
+
     metadata_requested = Signal(GUIComicInfo)
 
     def __init__(
@@ -215,6 +335,17 @@ class ComicGridView(QWidget):
         reading_controller: ReadingController,
         colums: int = 5,
     ):
+        """
+        Creates the inital grid of comics.
+
+        Args:
+            comics (list[GUIComicInfo]): The list of comic information to create
+            the grid from.
+            reading_controller (ReadingController): The application-wide reading
+            controller.
+            colums (int, optional): The number of columns to arrange the grid of
+            comic widgets into. Defaults to 5.
+        """
         super().__init__()
         self.comics = comics
         self.cont = reading_controller
@@ -236,12 +367,20 @@ class ComicGridView(QWidget):
         self.setLayout(basic_layout)
 
     def relayout_grid(self):
+        """
+        Triggered upon a resizing of the grid. Calculates the new number of columns
+        given the new width of the comic grid widget.
+        """
         width = self.scroll_area.viewport().width()
         item_width = 180 + 10
         columns = max(1, width // item_width)
         self.grid.relayout_grid(columns)
 
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        """
+        Watches for events and checks that they are resizing evenets. If so,
+        calls the resizing function.
+        """
         if (
             watched == self.scroll_area.viewport()
             and event.type() == QEvent.Type.Resize
@@ -251,9 +390,22 @@ class ComicGridView(QWidget):
 
 
 class DraggableComicGridView(QListWidget):
+    """
+    A class representing a collection of comic widgets, each of which
+    is draggable. Has type QListWidget.
+    """
+
     MIME_TYPE = "application/x-comic-id"
 
     def __init__(self, comics: list[GUIComicInfo]):
+        """
+        Creates the list (which looks like a grid) of draggable comic
+        widgets.
+
+        Args:
+            comics (list[GUIComicInfo]): The list of comic information to
+            add into the list.
+        """
         super().__init__()
 
         self.setViewMode(QListWidget.ViewMode.IconMode)
@@ -278,6 +430,10 @@ class DraggableComicGridView(QListWidget):
             self.addItem(item)
 
     def startDrag(self, supportedActions):
+        """
+        Starts the drag event by adding MIME data to the widget and creates a
+        smaller version of the comic thumbnail to follow the cursor during the drag.
+        """
         items = self.selectedItems()
         if not items:
             return

--- a/comic_grid_view.py
+++ b/comic_grid_view.py
@@ -1,5 +1,5 @@
-from PySide6.QtCore import QEvent, QMimeData, QObject, QSize, Qt, Signal
-from PySide6.QtGui import QDrag, QIcon
+from PySide6.QtCore import QEvent, QMimeData, QObject, QPoint, QSize, Qt, Signal
+from PySide6.QtGui import QDrag, QDragEnterEvent, QDragMoveEvent, QDropEvent, QIcon
 from PySide6.QtWidgets import (
     QGridLayout,
     QHBoxLayout,
@@ -19,51 +19,25 @@ from reader_controller import ReadingController
 from right_click_menus import GridViewContextMenuManager
 
 
-class ComicGridView(QWidget):
+class ComicGrid(QWidget):
     metadata_requested = Signal(GUIComicInfo)
 
     def __init__(
         self,
         comics: list[GUIComicInfo],
         reading_controller: ReadingController,
+        coll_names: list[str],
+        coll_ids: list[int],
         colums: int = 5,
-        collection: bool = False,
     ):
         super().__init__()
-        self.collection = collection
         self.comics = comics
         self.cont = reading_controller
-        with RepoWorker() as repo_worker:
-            collection_names, collection_ids = repo_worker.get_collections()
-        self.context_menu = GridViewContextMenuManager(collection_ids, collection_names)
+        self.context_menu = GridViewContextMenuManager(coll_ids, coll_names)
         self.comic_widgets: list[GeneralComicWidget] = []
 
-        basic_layout = QVBoxLayout()
-
-        self.scroll_area = self.create_scroll_area(colums)
-        self.scroll_area.viewport().installEventFilter(self)
-
-        basic_layout.addWidget(self.scroll_area)
-        if collection:
-            col_layout = QVBoxLayout()
-            self.splitter = QSplitter()
-            self.add_to_collection_button = QPushButton("Add..")
-            self.add_to_collection_button.clicked.connect(self.comic_explore_window)
-            col_layout.addWidget(self.scroll_area)
-            col_layout.addWidget(self.add_to_collection_button)
-            self.collection_content = QWidget()
-            self.collection_content.setLayout(col_layout)
-            self.splitter.addWidget(self.collection_content)
-            fin_layout = QHBoxLayout()
-            fin_layout.addWidget(self.splitter)
-            self.setLayout(fin_layout)
-        else:
-            self.setLayout(basic_layout)
-
-    def create_scroll_area(self, columns) -> QScrollArea:
-        self.grid_widget = QWidget()
-        self.grid_layout = QGridLayout(self.grid_widget)
-        self.grid_widget.setLayout(self.grid_layout)
+        self.columns = colums
+        self.grid_layout = QGridLayout(self)
         self.grid_layout.setSpacing(10)
         self.grid_layout.setContentsMargins(10, 10, 10, 10)
 
@@ -85,20 +59,98 @@ class ComicGridView(QWidget):
             )
 
             col += 1
-            if col >= columns:
+            if col >= self.columns:
                 col = 0
                 row += 1
 
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setWidget(self.grid_widget)
-        return scroll_area
+    def add_comics(self, comics: list[GUIComicInfo]):
+        start_index = len(self.comics)
+        for i, comic in enumerate(comics):
+            comic_widget = GeneralComicWidget(
+                comic,
+                single_left_click=self.metadata_panel,
+                single_right_click=self.context_menu.show_menu,
+                double_left_click=self.open_reader,
+                size=(180, 270),
+            )
+            self.comic_widgets.append(comic_widget)
+
+            index = start_index + i
+            row = index // self.columns
+            col = index % self.columns
+
+            self.grid_layout.addWidget(
+                comic_widget, row, col, alignment=Qt.AlignmentFlag.AlignTop
+            )
 
     def open_reader(self, comic_info: GUIComicInfo):
         self.cont.read_comic(comic_info)
 
     def metadata_panel(self, comic_info: GUIComicInfo):
         self.metadata_requested.emit(comic_info)
+
+    def relayout_grid(self, columns: int):
+        self.columns = columns
+        while self.grid_layout.count():
+            item = self.grid_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.setParent(None)
+
+        row = col = 0
+        for widget in self.comic_widgets:
+            self.grid_layout.addWidget(
+                widget, row, col, alignment=Qt.AlignmentFlag.AlignTop
+            )
+            col += 1
+            if col >= self.columns:
+                col = 0
+                row += 1
+
+
+class ComicCollectionGridView(QWidget):
+    def __init__(
+        self,
+        comics: list[GUIComicInfo],
+        reading_controller: ReadingController,
+        collection_id: int,
+        columns: int = 5,
+    ):
+        super().__init__()
+        self.coll_id = collection_id
+        self.col = columns
+        self.comics = comics
+        self.cont = reading_controller
+        with RepoWorker() as repo_worker:
+            collection_names, collection_ids = repo_worker.get_collections()
+        self.context_menu = GridViewContextMenuManager(collection_ids, collection_names)
+
+        self.grid = ComicGrid(
+            self.comics,
+            self.cont,
+            collection_names,
+            collection_ids,
+            self.col,
+        )
+
+        self.scroll_area = QScrollArea()
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setWidget(self.grid)
+        self.scroll_area.viewport().installEventFilter(self)
+
+        self.setAcceptDrops(True)
+        col_layout = QVBoxLayout()
+        self.splitter = QSplitter()
+        self.add_to_collection_button = QPushButton("Add..")
+        self.add_to_collection_button.clicked.connect(self.comic_explore_window)
+        col_layout.addWidget(self.scroll_area)
+        col_layout.addWidget(self.add_to_collection_button)
+        self.collection_content = QWidget()
+        self.collection_content.setLayout(col_layout)
+        self.splitter.addWidget(self.collection_content)
+        fin_layout = QHBoxLayout()
+        fin_layout.addWidget(self.splitter)
+        self.setLayout(fin_layout)
 
     def comic_explore_window(self):
         with RepoWorker() as repo_worker:
@@ -110,25 +162,91 @@ class ComicGridView(QWidget):
         width = self.scroll_area.viewport().width()
         item_width = 180 + 10
         columns = max(1, width // item_width)
-
-        while self.grid_layout.count():
-            self.grid_layout.takeAt(0)
-
-        row = col = 0
-        for widget in self.comic_widgets:
-            self.grid_layout.addWidget(widget, row, col)
-            col += 1
-            if col >= columns:
-                col = 0
-                row += 1
+        self.grid.relayout_grid(columns)
 
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
         if (
             watched == self.scroll_area.viewport()
             and event.type() == QEvent.Type.Resize
         ):
-            if self.collection:
-                self.relayout_grid()
+            self.relayout_grid()
+        return super().eventFilter(watched, event)
+
+    def dragEnterEvent(self, event: QDragEnterEvent) -> None:
+        if event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dragMoveEvent(self, event: QDragMoveEvent) -> None:
+        if event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dropEvent(self, event: QDropEvent) -> None:
+        if event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
+            data = event.mimeData().data(DraggableComicGridView.MIME_TYPE)
+
+            ids = bytes(data.data()).decode().split(",")
+            ids = [str(i) for i in ids]
+
+            print("Dropped comics IDs: ", ids)
+            self.handle_dropped_comic(ids)
+        else:
+            event.ignore()
+
+    def handle_dropped_comic(self, ids: list[str]):
+        with RepoWorker() as worker:
+            for i in ids:
+                worker.add_to_collection(self.coll_id, i)
+            updated = worker.create_basemodel(ids)
+
+        self.comics.extend(updated)
+        self.grid.add_comics(updated)
+
+
+class ComicGridView(QWidget):
+    metadata_requested = Signal(GUIComicInfo)
+
+    def __init__(
+        self,
+        comics: list[GUIComicInfo],
+        reading_controller: ReadingController,
+        colums: int = 5,
+    ):
+        super().__init__()
+        self.comics = comics
+        self.cont = reading_controller
+        with RepoWorker() as repo_worker:
+            collection_names, collection_ids = repo_worker.get_collections()
+        self.context_menu = GridViewContextMenuManager(collection_ids, collection_names)
+
+        self.grid = ComicGrid(
+            self.comics, self.cont, collection_names, collection_ids, colums
+        )
+
+        self.scroll_area = QScrollArea()
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setWidget(self.grid)
+        self.scroll_area.viewport().installEventFilter(self)
+
+        basic_layout = QVBoxLayout()
+        basic_layout.addWidget(self.scroll_area)
+        self.setLayout(basic_layout)
+
+    def relayout_grid(self):
+        width = self.scroll_area.viewport().width()
+        item_width = 180 + 10
+        columns = max(1, width // item_width)
+        self.grid.relayout_grid(columns)
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        if (
+            watched == self.scroll_area.viewport()
+            and event.type() == QEvent.Type.Resize
+        ):
+            self.relayout_grid()
         return super().eventFilter(watched, event)
 
 
@@ -171,4 +289,15 @@ class DraggableComicGridView(QListWidget):
 
         drag = QDrag(self)
         drag.setMimeData(mime)
+        item = items[0]
+        icon = item.icon()
+        pixmap = icon.pixmap(self.iconSize())
+        scaled = pixmap.scaled(
+            100,
+            150,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
+        drag.setPixmap(scaled)
+        drag.setHotSpot(QPoint(scaled.width() // 2, scaled.height() // 2))
         drag.exec(Qt.DropAction.CopyAction)

--- a/database/gui_repo_worker.py
+++ b/database/gui_repo_worker.py
@@ -482,10 +482,7 @@ class RepoWorker:
             (collection_id,),
         )
         result = self.cursor.fetchall()
-        if result:
-            return [r[0] for r in result]
-        else:
-            raise ValueError(f"Collection with id={collection_id} does not exist.")
+        return [r[0] for r in result]
 
     def create_reading_order(self, title: str, desc: Optional[str]) -> int:
         """

--- a/main.py
+++ b/main.py
@@ -203,7 +203,7 @@ class HomePage(QMainWindow):
             continue_list, progress_list
         )
         # need_review = self.create_review_area(review_list)
-        rss = self.create_rss_area(25)
+        rss = self.create_rss_area(10)
 
         # content_layout.addWidget(stats_bar, stretch=1)
         content_layout.addWidget(continue_reading, stretch=3)
@@ -601,7 +601,9 @@ class HomePage(QMainWindow):
                 return
             # TODO: Add method to communicate errors to user.
             comic_infos = worker.create_basemodel(comic_ids)
-        collection_grid = ComicGridView(comic_infos, self.reader_controller)
+        collection_grid = ComicGridView(
+            comic_infos, self.reader_controller, collection=True
+        )
         self.coll_display.addWidget(collection_grid)
         self.stack.setCurrentWidget(self.collections_widget)
 
@@ -663,6 +665,13 @@ class HomePage(QMainWindow):
             logging.error(f"[Async callback exception] {e}")
 
     def clear_widget_stack(self):
+        """
+        Remove and safely delete all widgets from the collection display layout.
+
+        Iterates through all items in 'self.coll_display', removes each item from
+        the layour and schedules its associated widgets for deletion using
+        'deleteLater()'.
+        """
         while self.coll_display.count():
             item = self.coll_display.takeAt(0)
             widget = item.widget()

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ from api.api_main import app
 from classes.helper_classes import GUIComicInfo, RSSComicInfo
 from cleanup import scan_and_clean
 from collections_widget import CollectionCreation
-from comic_grid_view import ComicGridView
+from comic_grid_view import ComicCollectionGridView, ComicGridView
 from comic_match_logic import ComicMatch
 from comic_match_ui import ComicMatcherUI
 from database.gui_repo_worker import RepoWorker
@@ -601,8 +601,8 @@ class HomePage(QMainWindow):
                 return
             # TODO: Add method to communicate errors to user.
             comic_infos = worker.create_basemodel(comic_ids)
-        collection_grid = ComicGridView(
-            comic_infos, self.reader_controller, collection=True
+        collection_grid = ComicCollectionGridView(
+            comic_infos, self.reader_controller, id
         )
         self.coll_display.addWidget(collection_grid)
         self.stack.setCurrentWidget(self.collections_widget)


### PR DESCRIPTION
Refactored the comic grid view to separate and modularise the codebase. This allows grid views to look the same but have different functionality without cluttering the class structure or many ``if'' statements. 

Added drag functionality to widgets in the collection view, this means users can easily add comics to collections by dragging. The UI also updates after this has happened, so they can see the new collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive comic grid with draggable items, incremental loading and a collection view that accepts drag-and-drop to add comics.
  * Improved drag visuals when dragging comics.

* **Bug Fixes**
  * Fixed handling of empty or missing collections so they return an empty list instead of raising an error.

* **Changes**
  * Reduced default RSS feed display from 25 to 10 items.
  * Grid now relayouts responsively on viewport resize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->