### PR TITLE
Reading orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ log.txt
 .bandit
 quick.py
 missing_stubs
+.mypy_cache/

--- a/comic_grid_view.py
+++ b/comic_grid_view.py
@@ -454,16 +454,9 @@ class DraggableComicGridView(QListWidget):
         self.setSpacing(10)
         self.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
 
+        self.acceptDrops()
         self.setDragEnabled(True)
         self.set_comics(comics)
-        # for comic in comics:
-        #     item = QListWidgetItem()
-        #     item.setData(Qt.ItemDataRole.UserRole, comic.primary_id)
-        #     item.setText(comic.title)
-        #     item.setIcon(QIcon(str(comic.cover_path)))
-        #     item.setToolTip(comic.title)
-
-        #     self.addItem(item)
 
     def startDrag(self, supportedActions):
         """

--- a/comic_grid_view.py
+++ b/comic_grid_view.py
@@ -112,6 +112,7 @@ class ComicGrid(QWidget):
             )
 
     def clear_grid(self):
+        """Get rid of all of the widgets on display."""
         for widget in self.comic_widgets:
             self.grid_layout.removeWidget(widget)
             widget.deleteLater()
@@ -119,6 +120,16 @@ class ComicGrid(QWidget):
         self.comic_widgets.clear()
 
     def reload_contents(self, comics: list[GUIComicInfo]):
+        """
+        Update the view with a new set of comics. This removes what
+        is currently displayed and then rebuilts the view from the new
+        data. It also sets the self.comics attribute to this new set of
+        comics - practically forgetting the originally passed in data.
+
+        Args:
+            comics (list[GUIComicInfo]): The list of comic information
+            to rebuilt the view from.
+        """
         self.clear_grid()
         self.comics = comics
 
@@ -488,6 +499,14 @@ class DraggableComicGridView(QListWidget):
         drag.exec(Qt.DropAction.CopyAction)
 
     def set_comics(self, comics: list[GUIComicInfo]):
+        """
+        Completely reloads the current selection of comics on show to the user
+        with the list passed into the function.
+
+        Args:
+            comics (list[GUIComicInfo]): The list of GUIComicInfo to update the
+            view with.
+        """
         self.clear()
 
         for comic in comics:

--- a/comic_grid_view.py
+++ b/comic_grid_view.py
@@ -130,33 +130,9 @@ class ComicGrid(QWidget):
             comics (list[GUIComicInfo]): The list of comic information
             to rebuild the view from.
         """
-        # self.clear_grid()
+        self.clear_grid()
         self.comics = comics
         self.add_comics(self.comics)
-
-        # row = col = 0
-        # for comic in self.comics:
-        #     comic_widget = GeneralComicWidget(
-        #         comic,
-        #         single_left_click=self.metadata_panel,
-        #         single_right_click=self.context_menu.show_menu,
-        #         double_left_click=self.open_reader,
-        #         size=(180, 270),
-        #     )
-
-        #     self.comic_widgets.append(comic_widget)
-
-        #     self.grid_layout.addWidget(
-        #         comic_widget,
-        #         row,
-        #         col,
-        #         alignment=Qt.AlignmentFlag.AlignTop,
-        #     )
-
-        #     col += 1
-        #     if col >= self.columns:
-        #         col = 0
-        #         row += 1
 
     def open_reader(self, comic_info: GUIComicInfo):
         """

--- a/comic_grid_view.py
+++ b/comic_grid_view.py
@@ -122,40 +122,41 @@ class ComicGrid(QWidget):
     def reload_contents(self, comics: list[GUIComicInfo]):
         """
         Update the view with a new set of comics. This removes what
-        is currently displayed and then rebuilts the view from the new
+        is currently displayed and then rebuilds the view from the new
         data. It also sets the self.comics attribute to this new set of
         comics - practically forgetting the originally passed in data.
 
         Args:
             comics (list[GUIComicInfo]): The list of comic information
-            to rebuilt the view from.
+            to rebuild the view from.
         """
-        self.clear_grid()
+        # self.clear_grid()
         self.comics = comics
+        self.add_comics(self.comics)
 
-        row = col = 0
-        for comic in self.comics:
-            comic_widget = GeneralComicWidget(
-                comic,
-                single_left_click=self.metadata_panel,
-                single_right_click=self.context_menu.show_menu,
-                double_left_click=self.open_reader,
-                size=(180, 270),
-            )
+        # row = col = 0
+        # for comic in self.comics:
+        #     comic_widget = GeneralComicWidget(
+        #         comic,
+        #         single_left_click=self.metadata_panel,
+        #         single_right_click=self.context_menu.show_menu,
+        #         double_left_click=self.open_reader,
+        #         size=(180, 270),
+        #     )
 
-            self.comic_widgets.append(comic_widget)
+        #     self.comic_widgets.append(comic_widget)
 
-            self.grid_layout.addWidget(
-                comic_widget,
-                row,
-                col,
-                alignment=Qt.AlignmentFlag.AlignTop,
-            )
+        #     self.grid_layout.addWidget(
+        #         comic_widget,
+        #         row,
+        #         col,
+        #         alignment=Qt.AlignmentFlag.AlignTop,
+        #     )
 
-            col += 1
-            if col >= self.columns:
-                col = 0
-                row += 1
+        #     col += 1
+        #     if col >= self.columns:
+        #         col = 0
+        #         row += 1
 
     def open_reader(self, comic_info: GUIComicInfo):
         """

--- a/comic_grid_view.py
+++ b/comic_grid_view.py
@@ -465,7 +465,6 @@ class DraggableComicGridView(QListWidget):
         self.setSpacing(10)
         self.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
 
-        self.acceptDrops()
         self.setDragEnabled(True)
         self.set_comics(comics)
 

--- a/database/gui_repo_worker.py
+++ b/database/gui_repo_worker.py
@@ -18,7 +18,7 @@ class RepoWorker:
         self.cover_folder = ROOT_DIR / ".covers"
 
     def __enter__(self):
-        self.conn = sqlite3.connect("comics.db")
+        self.conn = sqlite3.connect(DB_PATH)
         self.cursor = self.conn.cursor()
         return self
 
@@ -577,14 +577,13 @@ class RepoWorker:
                 (order_id,),
             )
 
-            for pos, comic_id in enumerate(comic_ids, start=1):
-                self.cursor.execute(
-                    """
+            self.cursor.executemany(
+                """
                 INSERT INTO reading_order_items (comic_id, reading_order_id, position)
                 VALUES (?, ?, ?)
                 """,
-                    (comic_id, order_id, pos),
-                )
+                ((cid, order_id, pos) for pos, cid in enumerate(comic_ids, start=1)),
+            )
 
     def get_order_contents(self, order_id: int) -> Optional[list[tuple[str, int]]]:
         """

--- a/database/gui_repo_worker.py
+++ b/database/gui_repo_worker.py
@@ -622,20 +622,21 @@ class RepoWorker:
             parent_id (int): The unique identifier of the collection
             to delete.
         """
-        self.cursor.execute(
-            """
-        DELETE FROM collections_contents
-        WHERE collection_id = ?
-        """,
-            (parent_id,),
-        )
-        self.cursor.execute(
-            """
-        DELETE FROM collections
-        WHERE id = ?
-        """,
-            (parent_id,),
-        )
+        with self.conn:
+            self.cursor.execute(
+                """
+            DELETE FROM collections_contents
+            WHERE collection_id = ?
+            """,
+                (parent_id,),
+            )
+            self.cursor.execute(
+                """
+            DELETE FROM collections
+            WHERE id = ?
+            """,
+                (parent_id,),
+            )
 
     def delete_order(self, parent_id: int) -> None:
         """
@@ -645,17 +646,18 @@ class RepoWorker:
             parent_id (int): The unique identifier of the reading order
             to delete.
         """
-        self.cursor.execute(
-            """
-        DELETE FROM reading_order_items
-        WHERE reading_order_id = ?
-        """,
-            (parent_id,),
-        )
-        self.cursor.execute(
-            """
-        DELETE FROM reading_orders
-        WHERE id = ?
-        """,
-            (parent_id,),
-        )
+        with self.conn:
+            self.cursor.execute(
+                """
+            DELETE FROM reading_order_items
+            WHERE reading_order_id = ?
+            """,
+                (parent_id,),
+            )
+            self.cursor.execute(
+                """
+            DELETE FROM reading_orders
+            WHERE id = ?
+            """,
+                (parent_id,),
+            )

--- a/database/gui_repo_worker.py
+++ b/database/gui_repo_worker.py
@@ -615,6 +615,13 @@ class RepoWorker:
             return None
 
     def delete_collection(self, parent_id: int) -> None:
+        """
+        Delete a collection and all its contents from the database.
+
+        Args:
+            parent_id (int): The unique identifier of the collection
+            to delete.
+        """
         self.cursor.execute(
             """
         DELETE FROM collections_contents
@@ -631,6 +638,13 @@ class RepoWorker:
         )
 
     def delete_order(self, parent_id: int) -> None:
+        """
+        Delete a reading order and all its contents from the database.
+
+        Args:
+            parent_id (int): The unique identifier of the reading order
+            to delete.
+        """
         self.cursor.execute(
             """
         DELETE FROM reading_order_items

--- a/database/gui_repo_worker.py
+++ b/database/gui_repo_worker.py
@@ -613,3 +613,35 @@ class RepoWorker:
             return [(r[0], r[1]) for r in result]
         else:
             return None
+
+    def delete_collection(self, parent_id: int) -> None:
+        self.cursor.execute(
+            """
+        DELETE FROM collections_contents
+        WHERE collection_id = ?
+        """,
+            (parent_id,),
+        )
+        self.cursor.execute(
+            """
+        DELETE FROM collections
+        WHERE id = ?
+        """,
+            (parent_id,),
+        )
+
+    def delete_order(self, parent_id: int) -> None:
+        self.cursor.execute(
+            """
+        DELETE FROM reading_order_items
+        WHERE reading_order_id = ?
+        """,
+            (parent_id,),
+        )
+        self.cursor.execute(
+            """
+        DELETE FROM reading_orders
+        WHERE id = ?
+        """,
+            (parent_id,),
+        )

--- a/database/gui_repo_worker.py
+++ b/database/gui_repo_worker.py
@@ -528,34 +528,24 @@ class RepoWorker:
 
         return (names, ids, desc)
 
-    def add_to_orders(self, order_id: int, comic_id: str, position: int):
-        current_order = self.get_order_contents(order_id)
-        if not current_order:
+    def add_to_order(self, order_id: int, comic_ids: list[str]) -> None:
+        with self.conn:
             self.cursor.execute(
                 """
+            DELETE FROM reading_order_items
+            WHERE reading_order_id = ?
+            """,
+                (order_id,),
+            )
+
+            for pos, comic_id in enumerate(comic_ids, start=1):
+                self.cursor.execute(
+                    """
                 INSERT INTO reading_order_items (comic_id, reading_order_id, position)
                 VALUES (?, ?, ?)
                 """,
-                (comic_id, order_id, 1),
-            )
-            return
-        self.cursor.execute(
-            """
-            INSERT INTO reading_order_items (comic_id, reading_order_id, position)
-            VALUES (?, ?, ?)
-            """,
-            (comic_id, order_id, position),
-        )
-        for primary_key, pos in current_order[: position - 1]:
-            self.cursor.execute(
-                """
-                UPDATE reading_order_items
-                SET position = ?
-                WHERE comic_d = ? and reading_order_id = ?
-                """,
-                ((pos + 1, primary_key, order_id)),
-            )
-        return
+                    (comic_id, order_id, pos),
+                )
 
     def get_order_contents(self, order_id: int) -> Optional[list[tuple[str, int]]]:
         self.cursor.execute(

--- a/database/gui_repo_worker.py
+++ b/database/gui_repo_worker.py
@@ -10,6 +10,7 @@ from classes.helper_classes import GUIComicInfo, MetadataInfo
 
 load_dotenv()
 ROOT_DIR = Path(os.getenv("ROOT_DIR") or "")
+DB_PATH = Path(os.getenv("DB_PATH") or "comics.db")
 
 
 class RepoWorker:
@@ -72,6 +73,15 @@ class RepoWorker:
         return comic_info
 
     def get_all_comics(self, **thumb: bool) -> list[GUIComicInfo]:
+        """
+        Gets the GUI information for every comic in the database.
+        The size of the cover image can be specified by the keyword
+        argument "thumb".
+
+        Returns:
+            list[GUIComicInfo]: A list of the GUIComicInfo for every
+            comic in the database.
+        """
         self.cursor.execute("SELECT id FROM comics")
         rows = self.cursor.fetchall()
         ids = [row[0] for row in rows]
@@ -81,6 +91,15 @@ class RepoWorker:
             return self.create_basemodel(ids)
 
     def comic_in_db(self, filepath: Path) -> bool:
+        """
+        Checks whether a comic with a certain filepath is in the database.
+
+        Args:
+            filepath (Path): The filepath of the comic to check.
+
+        Returns:
+            bool: True if it is in the database, False otherwise.
+        """
         rel_path = filepath.relative_to(ROOT_DIR)
         self.cursor.execute(
             "SELECT * FROM comics WHERE file_path = ? LIMIT 1", (str(rel_path),)
@@ -516,6 +535,16 @@ class RepoWorker:
         return self.cursor.lastrowid or 0
 
     def get_orders(self) -> tuple[list[str], list[int], list[str]]:
+        """
+        Gets all of the current reading orders, even ones that are empty.
+
+        Returns:
+            tuple[list[str], list[int], list[str]]: A tuple of three elements;
+            a list of the reading order names, a list of the ids and a list of
+            the reading order descriptions. The lists all have the same order,
+            so the i'th element of each list corresponds to the same reading
+            order.
+        """
         self.cursor.execute("SELECT name, id, description from reading_orders")
         results = self.cursor.fetchall()
         names = []
@@ -529,6 +558,16 @@ class RepoWorker:
         return (names, ids, desc)
 
     def add_to_order(self, order_id: int, comic_ids: list[str]) -> None:
+        """
+        Adds a list of comic_ids to the reading order. The full list of comic_ids
+        must be passed in as this overwrites the order each time instead of
+        complicated list comparisons.
+
+        Args:
+            order_id (int): The id of the reading order.
+            comic_ids (list[str]): The FULL list of comic_id's for the reading
+            order
+        """
         with self.conn:
             self.cursor.execute(
                 """
@@ -548,6 +587,18 @@ class RepoWorker:
                 )
 
     def get_order_contents(self, order_id: int) -> Optional[list[tuple[str, int]]]:
+        """
+        Gets the current contents of a reading order from the database.
+
+        Args:
+            order_id (int): The id of the reading order being queried.
+
+        Returns:
+            Optional[list[tuple[str, int]]]: A list of tuples, where the first element
+            is the comic_id and the second is the position within the order.
+        """
+        # ? Perhaps having the tuples is redundant since just a list of strings can
+        # ? communicate order.
         self.cursor.execute(
             """
             SELECT comic_id, position

--- a/left_widget_assets.py
+++ b/left_widget_assets.py
@@ -39,7 +39,7 @@ class StyledButton(QWidget):
             """
 
         self.menu = QMenu(self)
-        edit_action = self.menu.addAction("Edit reading order")
+        edit_action = self.menu.addAction("Edit")
         delete_action = self.menu.addAction("Delete")
         edit_action.triggered.connect(self._edit)
         delete_action.triggered.connect(self._delete)
@@ -76,6 +76,7 @@ class ButtonDisplay(QWidget):
         ids: list[int],
         left_clicked: Callable,
         order_edit: Callable | None = None,
+        delete: Callable | None = None,
     ):
         super().__init__()
 
@@ -95,6 +96,8 @@ class ButtonDisplay(QWidget):
             widget.clicked.connect(left_clicked)
             if order_edit:
                 widget.editOrder.connect(order_edit)
+            if delete:
+                widget.deleteOrder.connect(delete)
             widget.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
             layout.addWidget(widget)
 

--- a/main.py
+++ b/main.py
@@ -649,7 +649,6 @@ class HomePage(QMainWindow):
     def order_search(self, text: str):
         display_info = text_search(text)
         self.order_editor.library_panel.set_comics(display_info or [])
-        return
 
     def open_settings(self):
         dialog = Settings()

--- a/main.py
+++ b/main.py
@@ -50,7 +50,6 @@ from reader_controller import ReadingController
 from reading_order_widget import (
     ReadingOrderCreation,
     ReadingOrderEditor,
-    ReadingOrderListEditor,
 )
 from rss.rss_controller import RSSController
 from rss.rss_repository import RSSRepository
@@ -546,6 +545,14 @@ class HomePage(QMainWindow):
             previous = getattr(self, "sidebar_width", 150)
             self.splitter.setSizes([previous, sizes[1]])
 
+    def collapse_sidebar(self):
+        sizes = self.splitter.sizes()
+        if sizes[0] > 0:
+            self.sidebar_width = sizes[0]
+            self.splitter.setSizes([0, sizes[1] + sizes[0]])
+        else:
+            return
+
     def go_home(self):
         self.stack.setCurrentWidget(self.content_area)
 
@@ -555,6 +562,8 @@ class HomePage(QMainWindow):
         current = self.stack.currentWidget()
         if current == self.collections_widget:
             self.collection_search(text)
+        elif current == self.order_widget:
+            self.order_search(text)
         else:
             self.library_search(text)
 
@@ -636,28 +645,24 @@ class HomePage(QMainWindow):
             logging.info(dialog.textbox.text())
 
     def clicked_reading_order(self, id: int, name: str):
+        self.collapse_sidebar()
         self.clear_widget_stack()
-        # with RepoWorker() as worker:
-        #     try:
-        #         comics = worker.get_order_contents(id)
-        #     except ValueError as e:
-        #         print(str(e))
-        #         return
-        #     comic_ids: list[str] = []
-        #     positions: list[int] = []
-        #     for key, pos in comics:
-        #         comic_ids.append(key)
-        #         positions.append(pos)
-        #     comic_infos = worker.create_basemodel(comic_ids)
-        order_list = ReadingOrderListEditor(id, name)
-        self.order_display_.addWidget(order_list)
+        self.order_editor = ReadingOrderEditor(id, name)
+        self.order_display_.addWidget(self.order_editor)
         self.stack.setCurrentWidget(self.order_widget)
+
+    def order_search(self, text: str):
+        display_info = text_search(text)
+        if display_info is None:
+            # TODO: Need to add logic here.
+            raise ValueError("Incorrect type passed!")
+        self.order_editor.library_panel.set_comics(display_info)
 
     def open_order_editor(self, id: int, name: str):
         self.order_editor = ReadingOrderEditor(id, name)
         self.order_editor.setWindowFlag(Qt.WindowType.Window)
         # order_editor.show()
-        self.order_editor.showFullScreen()
+        # self.order_editor.showFullScreen()
 
     def open_settings(self):
         dialog = Settings()

--- a/main.py
+++ b/main.py
@@ -185,7 +185,7 @@ class HomePage(QMainWindow):
             order_names,
             order_ids,
             self.clicked_reading_order,
-            order_edit=self.open_order_editor,
+            order_edit=self.clicked_reading_order,
         )
         left_layout.addWidget(self.order_display, stretch=1)
         self.splitter = QSplitter()
@@ -657,12 +657,6 @@ class HomePage(QMainWindow):
             # TODO: Need to add logic here.
             raise ValueError("Incorrect type passed!")
         self.order_editor.library_panel.set_comics(display_info)
-
-    def open_order_editor(self, id: int, name: str):
-        self.order_editor = ReadingOrderEditor(id, name)
-        self.order_editor.setWindowFlag(Qt.WindowType.Window)
-        # order_editor.show()
-        # self.order_editor.showFullScreen()
 
     def open_settings(self):
         dialog = Settings()

--- a/main.py
+++ b/main.py
@@ -176,7 +176,8 @@ class HomePage(QMainWindow):
             "Collections",
             collection_names,
             collection_ids,
-            self.clicked_collection,
+            left_clicked=self.clicked_collection,
+            delete=self.delete_col,
         )
         left_layout.addWidget(self.collection_display, stretch=1)
 
@@ -184,8 +185,8 @@ class HomePage(QMainWindow):
             "Reading Orders",
             order_names,
             order_ids,
-            self.clicked_reading_order,
-            order_edit=self.clicked_reading_order,
+            left_clicked=self.clicked_reading_order,
+            delete=self.delete_ord,
         )
         left_layout.addWidget(self.order_display, stretch=1)
         self.splitter = QSplitter()
@@ -654,6 +655,14 @@ class HomePage(QMainWindow):
         dialog = Settings()
         if dialog.exec() == QDialog.DialogCode.Accepted:
             return
+
+    def delete_col(self, identifier: int) -> None:
+        with RepoWorker() as worker:
+            worker.delete_collection(identifier)
+
+    def delete_ord(self, identifier: int) -> None:
+        with RepoWorker() as worker:
+            worker.delete_order(identifier)
 
     def update_status(self, message: str) -> None:
         """

--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ from settings import Settings
 load_dotenv()
 root_string = os.getenv("ROOT_DIR")
 ROOT_DIR = Path(root_string if root_string is not None else "")
-
+DB_PATH = Path(os.getenv("DB_PATH") or "comics.db")
 log_file = open("debug.log", "w", encoding="utf-8")
 sys.stdout = log_file
 sys.stderr = log_file
@@ -385,7 +385,7 @@ class HomePage(QMainWindow):
         creates a scroll area with download functionality
         for each comic.
         """
-        repository = RSSRepository("comics.db")
+        repository = RSSRepository(DB_PATH)
         rss_cont = RSSController(repository)
         recent_comics_list = rss_cont.run(num)
         self.download_controller = DownloadControllerAsync(view=self)
@@ -584,16 +584,10 @@ class HomePage(QMainWindow):
     def collection_search(self, text: str):
         if self.collection_grid.explore:
             display_info = text_search(text)
-            if display_info is None:
-                # TODO: Need to add logic here.
-                raise ValueError("Incorrect type passed!")
-            self.collection_grid.all_comics.set_comics(display_info)
+            self.collection_grid.all_comics.set_comics(display_info or [])
         else:
             display_info = collection_search(text, self.collection_grid.coll_id)
-            if display_info is None:
-                # TODO: Need to add logic here.
-                raise ValueError("Incorrect type passed!")
-            self.collection_grid.grid.reload_contents(display_info)
+            self.collection_grid.grid.reload_contents(display_info or [])
 
     def open_review_panel(self, comic_info: GUIComicInfo):
         self.metadata_popup = MetadataDialog(comic_info)
@@ -653,10 +647,8 @@ class HomePage(QMainWindow):
 
     def order_search(self, text: str):
         display_info = text_search(text)
-        if display_info is None:
-            # TODO: Need to add logic here.
-            raise ValueError("Incorrect type passed!")
-        self.order_editor.library_panel.set_comics(display_info)
+        self.order_editor.library_panel.set_comics(display_info or [])
+        return
 
     def open_settings(self):
         dialog = Settings()
@@ -695,13 +687,14 @@ class HomePage(QMainWindow):
         'deleteLater()'.
 
         Args:
-            layout (QHBoxLayout | QVBoxLayout): The layout to delete clear
+            layout (QHBoxLayout | QVBoxLayout): The layout to delete
             the widgets from.
         """
         while layout.count():
             item = layout.takeAt(0)
             widget = item.widget()
             if widget:
+                widget.setParent(None)
                 widget.deleteLater()
 
 

--- a/main.py
+++ b/main.py
@@ -624,7 +624,7 @@ class HomePage(QMainWindow):
             logging.info(dialog.textbox.text())
 
     def clicked_collection(self, id: int, name: str):
-        self.clear_widget_stack()
+        self.clear_layout(self.coll_display)
         with RepoWorker() as worker:
             try:
                 comic_ids = worker.get_collection_contents(id)
@@ -646,7 +646,7 @@ class HomePage(QMainWindow):
 
     def clicked_reading_order(self, id: int, name: str):
         self.collapse_sidebar()
-        self.clear_widget_stack()
+        self.clear_layout(self.order_display_)
         self.order_editor = ReadingOrderEditor(id, name)
         self.order_display_.addWidget(self.order_editor)
         self.stack.setCurrentWidget(self.order_widget)
@@ -686,16 +686,20 @@ class HomePage(QMainWindow):
         except Exception as e:
             logging.error(f"[Async callback exception] {e}")
 
-    def clear_widget_stack(self):
+    def clear_layout(self, layout: QHBoxLayout | QVBoxLayout) -> None:
         """
-        Remove and safely delete all widgets from the collection display layout.
+        Remove and safely delete all widgets from a layout.
 
-        Iterates through all items in 'self.coll_display', removes each item from
-        the layour and schedules its associated widgets for deletion using
+        Iterates through all items in the layout, removes each item from
+        the layout and schedules its associated widgets for deletion using
         'deleteLater()'.
+
+        Args:
+            layout (QHBoxLayout | QVBoxLayout): The layout to delete clear
+            the widgets from.
         """
-        while self.coll_display.count():
-            item = self.coll_display.takeAt(0)
+        while layout.count():
+            item = layout.takeAt(0)
             widget = item.widget()
             if widget:
                 widget.deleteLater()

--- a/reading_order_widget.py
+++ b/reading_order_widget.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from classes.helper_classes import GUIComicInfo
 from comic_grid_view import DraggableComicGridView
 from database.gui_repo_worker import RepoWorker
 
@@ -104,7 +105,7 @@ class ReadingOrderList(QListWidget):
 
         self.setAcceptDrops(True)
         self.setWindowTitle("Draggable List")
-        self.setDragDropMode(QListWidget.DragDropMode.InternalMove)
+        self.setDragDropMode(QListWidget.DragDropMode.DragDrop)
         self.setDropIndicatorShown(True)
         self.setDefaultDropAction(Qt.DropAction.MoveAction)
         self.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
@@ -139,12 +140,25 @@ class ReadingOrderList(QListWidget):
         with RepoWorker() as worker:
             comic_info = worker.create_basemodel(ids_in_order, thumb=True)
         for comic in comic_info:
-            item = QListWidgetItem(comic.title)
-            item.setData(Qt.ItemDataRole.UserRole, comic.primary_id)
-            item.setSizeHint(QSize(100, 180))
-            pixmap = self.get_comic_icon(comic.cover_path)
-            item.setData(Qt.ItemDataRole.DecorationRole, pixmap)
-            self.addItem(item)
+            self.addItem(self.build_item(comic))
+
+    def build_item(self, comic: GUIComicInfo) -> QListWidgetItem:
+        """
+        Creates the QListWidgetItem object by adding a title and a picture.
+
+        Args:
+            comic (GUIComicInfo): The UI facing comic information.
+
+        Returns:
+            QListWidgetItem: The object that is created to go into the list.
+        """
+        item = QListWidgetItem(comic.title)
+        item.setData(Qt.ItemDataRole.UserRole, comic.primary_id)
+        item.setSizeHint(QSize(100, 180))
+        item.setData(
+            Qt.ItemDataRole.DecorationRole, self.get_comic_icon(comic.cover_path)
+        )
+        return item
 
     def get_current_order(self) -> list[str]:
         """
@@ -193,10 +207,7 @@ class ReadingOrderList(QListWidget):
             return
 
         item = self.takeItem(start)
-        widget = self.itemWidget(item)
-        self.removeItemWidget(item)
         self.insertItem(end, item)
-        self.setItemWidget(item, widget)
 
     def add_comic(self, comic_id: str, row: int):
         """
@@ -213,14 +224,7 @@ class ReadingOrderList(QListWidget):
 
         with RepoWorker() as worker:
             comic = worker.create_basemodel([comic_id], thumb=True)[0]
-
-        item = QListWidgetItem(comic.title)
-        item.setData(Qt.ItemDataRole.UserRole, comic_id)
-        item.setSizeHint(QSize(100, 180))
-        pixmap = self.get_comic_icon(comic.cover_path)
-
-        item.setData(Qt.ItemDataRole.DecorationRole, pixmap)
-        self.insertItem(row, item)
+        self.insertItem(row, self.build_item(comic))
 
     def contains_comic(self, comic_id: str) -> bool:
         """
@@ -318,8 +322,8 @@ class ReadingOrderList(QListWidget):
             insert_row = self.indexAt(event.position().toPoint()).row()
             if insert_row < 0:
                 insert_row = self.count()
-            for i in comic_ids and positions:
-                self.move_item(i, insert_row)
+            pos = positions[0]
+            self.move_item(pos, insert_row)
             event.acceptProposedAction()
 
         elif event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):

--- a/reading_order_widget.py
+++ b/reading_order_widget.py
@@ -1,8 +1,9 @@
+import json
 from pathlib import Path
 from typing import Optional
 
-from PySide6.QtCore import QSize, Qt
-from PySide6.QtGui import QPixmap
+from PySide6.QtCore import QMimeData, QPoint, QSize, Qt
+from PySide6.QtGui import QDrag, QPixmap
 from PySide6.QtWidgets import (
     QDialog,
     QHBoxLayout,
@@ -11,6 +12,7 @@ from PySide6.QtWidgets import (
     QListWidget,
     QListWidgetItem,
     QPushButton,
+    QSplitter,
     QVBoxLayout,
     QWidget,
 )
@@ -71,27 +73,28 @@ class CustomListWidget(QWidget):
         super().__init__()
         self.setFixedHeight(100)
         image_label = QLabel()
-        pixmap = QPixmap(str(image_path))
-        image_label.setFixedSize(50, 80)
+        image_label.setFixedSize(120, 160)
         image_label.setScaledContents(True)
-        image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        image_label.setPixmap(
-            pixmap.scaled(
-                image_label.size(),
-                Qt.AspectRatioMode.KeepAspectRatio,
-                Qt.TransformationMode.SmoothTransformation,
-            )
+        image_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        self.pixmap = QPixmap(str(image_path))
+        self.pixmap = self.pixmap.scaled(
+            image_label.size(),
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
         )
+        image_label.setPixmap(self.pixmap)
 
         name_label = QLabel(name)
+        name_label.setAlignment(Qt.AlignmentFlag.AlignVCenter)
 
         main_layout = QHBoxLayout(self)
         main_layout.addWidget(image_label)
         main_layout.addWidget(name_label)
+        self.setLayout(main_layout)
 
 
-class ReadingOrderListEditor(QListWidget):
-    MIME_TYPE = "application/x-comic-id"
+class ReadingOrderList(QListWidget):
+    MIME_TYPE = "application/x-comic-order-id"
 
     def __init__(self, order_id: int, order_name: str):
         super().__init__()
@@ -119,14 +122,14 @@ class ReadingOrderListEditor(QListWidget):
             ids_in_order = [c[0] for c in order]
         with RepoWorker() as worker:
             comic_info = worker.create_basemodel(ids_in_order, thumb=True)
-        comic_info.reverse()
+        # comic_info.reverse()
         for comic in comic_info:
-            item = QListWidgetItem()
-            widget = CustomListWidget(name=comic.title, image_path=comic.cover_path)
-            item.setSizeHint(widget.sizeHint())
+            item = QListWidgetItem(comic.title)
             item.setData(Qt.ItemDataRole.UserRole, comic.primary_id)
+            item.setSizeHint(QSize(100, 180))
+            pixmap = self.get_comic_icon(comic.cover_path)
+            item.setData(Qt.ItemDataRole.DecorationRole, pixmap)
             self.addItem(item)
-            self.setItemWidget(item, widget)
 
     def get_current_order(self) -> list[str]:
         ids = []
@@ -135,6 +138,22 @@ class ReadingOrderListEditor(QListWidget):
             ids.append(item.data(Qt.ItemDataRole.UserRole))
         return ids
 
+    def get_position(self, comic_id: str) -> int:
+        for i in range(self.count()):
+            if self.item(i).data(Qt.ItemDataRole.UserRole) == comic_id:
+                return i
+        raise ValueError("Cannot find widget in current list.")
+
+    def move_item(self, start: int, end: int):
+        if start == end:
+            return
+
+        item = self.takeItem(start)
+        widget = self.itemWidget(item)
+        self.removeItemWidget(item)
+        self.insertItem(end, item)
+        self.setItemWidget(item, widget)
+
     def add_comic(self, comic_id: str, row: int):
         if self.contains_comic(comic_id):
             return
@@ -142,14 +161,15 @@ class ReadingOrderListEditor(QListWidget):
         with RepoWorker() as worker:
             comic = worker.create_basemodel([comic_id], thumb=True)[0]
 
-        item = QListWidgetItem()
+        item = QListWidgetItem(comic.title)
         item.setData(Qt.ItemDataRole.UserRole, comic_id)
-        item.setSizeHint(QSize(180, 270))
+        item.setSizeHint(QSize(100, 180))
+        pixmap = self.get_comic_icon(comic.cover_path)
 
-        widget = CustomListWidget(name=comic.title, image_path=comic.cover_path)
-
+        # widget = CustomListWidget(name=comic.title, image_path=comic.cover_path)
+        item.setData(Qt.ItemDataRole.DecorationRole, pixmap)
+        # self.setItemWidget(item, widget)
         self.insertItem(row, item)
-        self.setItemWidget(item, widget)
 
     def contains_comic(self, comic_id: str) -> bool:
         for i in range(self.count()):
@@ -157,8 +177,37 @@ class ReadingOrderListEditor(QListWidget):
                 return True
         return False
 
+    def startDrag(self, supportedActions) -> None:
+        items = self.selectedItems()
+        if not items:
+            return
+
+        ids = [item.data(Qt.ItemDataRole.UserRole) for item in items]
+        positions = []
+        for i in ids:
+            positions.append(self.get_position(i))
+        payload = {"comic_ids": ids, "positions": positions}
+
+        mime = QMimeData()
+        mime.setData(self.MIME_TYPE, json.dumps(payload).encode())
+        drag = QDrag(self)
+        drag.setMimeData(mime)
+        item = items[0]
+        pixmap = item.data(Qt.ItemDataRole.DecorationRole)
+        scaled = pixmap.scaled(
+            120,
+            180,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
+        drag.setPixmap(scaled)
+        drag.setHotSpot(QPoint(scaled.width() // 2, scaled.height() // 2))
+        drag.exec(Qt.DropAction.CopyAction)
+
     def dragEnterEvent(self, event) -> None:
         if event.mimeData().hasFormat(self.MIME_TYPE):
+            event.acceptProposedAction()
+        elif event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
             event.acceptProposedAction()
         else:
             event.ignore()
@@ -166,43 +215,81 @@ class ReadingOrderListEditor(QListWidget):
     def dragMoveEvent(self, event) -> None:
         if event.mimeData().hasFormat(self.MIME_TYPE):
             event.acceptProposedAction()
+        elif event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
+            event.acceptProposedAction()
         else:
             event.ignore()
 
     def dropEvent(self, event) -> None:
-        if not event.mimeData().hasFormat(self.MIME_TYPE):
-            event.ignore()
-            return
+        if event.mimeData().hasFormat(self.MIME_TYPE):
+            data = event.mimeData().data(self.MIME_TYPE)
+            payload = json.loads(bytes(data).decode())
 
-        comic_id = str(bytes(event.mimeData().data(self.MIME_TYPE)).decode())
+            comic_ids = payload["comic_ids"]
+            positions = payload["positions"]
+            if len(comic_ids) != 1:
+                return
 
-        insert_row = self.indexAt(event.position().toPoint()).row()
-        if insert_row < 0:
-            insert_row = self.count()
+            insert_row = self.indexAt(event.position().toPoint()).row()
+            if insert_row < 0:
+                insert_row = self.count()
+            for i in comic_ids and positions:
+                self.move_item(i, insert_row)
+            event.acceptProposedAction()
 
-        self.add_comic(comic_id, insert_row)
-        event.acceptProposedAction()
+        elif event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
+            data = event.mimeData().data(DraggableComicGridView.MIME_TYPE)
+            comic_ids = bytes(data.data()).decode().split(",")
+            comic_ids = [str(i) for i in comic_ids]
+            insert_row = self.indexAt(event.position().toPoint()).row()
+            if insert_row < 0:
+                insert_row = self.count()
+            for i in comic_ids:
+                self.add_comic(i, insert_row)
+            event.acceptProposedAction()
+
+    @staticmethod
+    def get_comic_icon(image_path: Path) -> QPixmap:
+        pixmap = QPixmap(str(image_path))
+        return pixmap.scaled(
+            QSize(120, 160),
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
 
 
 class ReadingOrderEditor(QWidget):
     def __init__(self, order_id: int, order_title: str):
         super().__init__()
         self.order_id = order_id
+        self.order_title = order_title
 
-        self.setWindowTitle("Edit Reading Order")
-        self.resize(1200, 800)
+        # self.setWindowTitle("Edit Reading Order")
+        # self.resize(1200, 800)
 
-        main_layout = QHBoxLayout(self)
-        main_layout.setSpacing(12)
-
+        dummy_layout = QHBoxLayout(self)
+        # main_layout.setSpacing(12)
+        self.splitter = QSplitter()
         with RepoWorker() as worker:
             all_comics = worker.get_all_comics()
 
         self.library_panel = DraggableComicGridView(all_comics)
-        self.order_panel = ReadingOrderListEditor(order_id, order_title)
+        self.order_panel = ReadingOrderList(order_id, order_title)
+        self.save_button = QPushButton("Save Current Order")
+        self.left_widget = QWidget()
+        self.left_layout = QVBoxLayout(self.left_widget)
+        self.left_layout.addWidget(self.order_panel)
+        self.left_layout.addWidget(self.save_button)
+        self.save_button.clicked.connect(self.save_order)
+        self.splitter.addWidget(self.left_widget)
+        self.splitter.addWidget(self.library_panel)
+        dummy_layout.addWidget(self.splitter)
 
-        main_layout.addWidget(self.library_panel, 3)
-        main_layout.addWidget(self.order_panel, 2)
+    def save_order(self):
+        order = self.order_panel.get_current_order()
+        # print("The current order is: ", order)
+        with RepoWorker() as repo:
+            repo.add_to_order(self.order_id, order)
 
 
 class ReadingOrderView(QWidget):

--- a/reading_order_widget.py
+++ b/reading_order_widget.py
@@ -22,7 +22,17 @@ from database.gui_repo_worker import RepoWorker
 
 
 class ReadingOrderCreation(QDialog):
+    """
+    A class for a popup window which creates a reading order in the database.
+
+    Subclasses QDialog.
+    """
+
     def __init__(self):
+        """
+        Creates the standard dialog window with two text boxes, one for the
+        reading order name and the other for the description.
+        """
         super().__init__()
 
         self.main_display = QWidget()
@@ -52,51 +62,42 @@ class ReadingOrderCreation(QDialog):
         self.setLayout(self.main_layout)
 
     def create_order(self):
+        """
+        Creates the database with the text inside the text boxes.
+        This function is triggered when the user presses the "Create order"
+        button. After the database has been written to, the dialog window
+        closes.
+        """
         name = self.textbox.text()
         description = self.textbox2.text()
 
         with RepoWorker() as worker:
             if description == "":
                 description = None
-            order_int = worker.create_reading_order(name, description)
+            worker.create_reading_order(name, description)
 
-        self.open_order_creation(order_int, name)
         self.close()
-
-    def open_order_creation(self, order_id: int, order_title: str):
-        self.order_editor = ReadingOrderEditor(order_id, order_title)
-        self.order_editor.show()
-
-
-class CustomListWidget(QWidget):
-    def __init__(self, name: str, image_path: Path):
-        super().__init__()
-        self.setFixedHeight(100)
-        image_label = QLabel()
-        image_label.setFixedSize(120, 160)
-        image_label.setScaledContents(True)
-        image_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        self.pixmap = QPixmap(str(image_path))
-        self.pixmap = self.pixmap.scaled(
-            image_label.size(),
-            Qt.AspectRatioMode.KeepAspectRatio,
-            Qt.TransformationMode.SmoothTransformation,
-        )
-        image_label.setPixmap(self.pixmap)
-
-        name_label = QLabel(name)
-        name_label.setAlignment(Qt.AlignmentFlag.AlignVCenter)
-
-        main_layout = QHBoxLayout(self)
-        main_layout.addWidget(image_label)
-        main_layout.addWidget(name_label)
-        self.setLayout(main_layout)
 
 
 class ReadingOrderList(QListWidget):
+    """
+    A class for representing an order of comic widgets.
+    This subclasses QListWidget.
+    """
+
     MIME_TYPE = "application/x-comic-order-id"
 
     def __init__(self, order_id: int, order_name: str):
+        """
+        Creates the original reading order just from information
+        collected from the database. Adds the widgets in the order
+        taken from the database.
+
+        Args:
+            order_id (int): The id of the reading order to query the db for.
+            order_name (str): The name of the reading order for display
+            purposes.
+        """
         super().__init__()
         self.order_id = order_id
         self.order_name = order_name
@@ -111,10 +112,25 @@ class ReadingOrderList(QListWidget):
         self.create_list_items()
 
     def get_db_order(self) -> Optional[list[tuple[str, int]]]:
+        """
+        Gets the current reading order from the database. Queries the
+        database each time this is called to remove stale data.
+
+        Returns:
+            Optional[list[tuple[str, int]]]: The list which represents
+            the ordered comics, None if there are no comics in the database
+            or the database does not exist.
+        """
+        # ? Perhaps this can be removed and just called directly?
         with RepoWorker() as worker:
             return worker.get_order_contents(self.order_id)
 
     def create_list_items(self) -> None:
+        """
+        Creates the display of comic widgets. For each comic in the ordered
+        list it adds a small image to the left and the name of the comic in
+        the middle.
+        """
         order = self.get_db_order()
         if order is None:
             ids_in_order = []
@@ -122,7 +138,6 @@ class ReadingOrderList(QListWidget):
             ids_in_order = [c[0] for c in order]
         with RepoWorker() as worker:
             comic_info = worker.create_basemodel(ids_in_order, thumb=True)
-        # comic_info.reverse()
         for comic in comic_info:
             item = QListWidgetItem(comic.title)
             item.setData(Qt.ItemDataRole.UserRole, comic.primary_id)
@@ -132,6 +147,14 @@ class ReadingOrderList(QListWidget):
             self.addItem(item)
 
     def get_current_order(self) -> list[str]:
+        """
+        Gets the current order of comics in the display after the user
+        has moved them around.
+
+        Returns:
+            list[str]: A list of the comic_id's where the order of the list
+            is the order of the comics also.
+        """
         ids = []
         for i in range(self.count()):
             item = self.item(i)
@@ -139,12 +162,33 @@ class ReadingOrderList(QListWidget):
         return ids
 
     def get_position(self, comic_id: str) -> int:
+        """
+        Finds the position in the list of a certain comic widget.
+
+        Args:
+            comic_id (str): The comic id to look for in the list.
+
+        Raises:
+            ValueError: Occurs if the comic id cannot be found anywhere
+            in the list, so there must be stale data somewhere.
+
+        Returns:
+            int: The position of the comic widget, zero indexed.
+        """
+        # ? Is zero-indexing here wrong? Should we start from 1?
         for i in range(self.count()):
             if self.item(i).data(Qt.ItemDataRole.UserRole) == comic_id:
                 return i
         raise ValueError("Cannot find widget in current list.")
 
     def move_item(self, start: int, end: int):
+        """
+        Moves the position of a widget within the list.
+
+        Args:
+            start (int): The position in the list of the widget to be moved.
+            end (int): The position to move the widget to.
+        """
         if start == end:
             return
 
@@ -155,6 +199,15 @@ class ReadingOrderList(QListWidget):
         self.setItemWidget(item, widget)
 
     def add_comic(self, comic_id: str, row: int):
+        """
+        Adds a new comic to the list in the provided position.
+
+        Args:
+            comic_id (str): The ID of the comic to be added so
+            its information can be taken from the database.
+            row (int): The position in the list to input the new
+            widget into.
+        """
         if self.contains_comic(comic_id):
             return
 
@@ -166,18 +219,36 @@ class ReadingOrderList(QListWidget):
         item.setSizeHint(QSize(100, 180))
         pixmap = self.get_comic_icon(comic.cover_path)
 
-        # widget = CustomListWidget(name=comic.title, image_path=comic.cover_path)
         item.setData(Qt.ItemDataRole.DecorationRole, pixmap)
-        # self.setItemWidget(item, widget)
         self.insertItem(row, item)
 
     def contains_comic(self, comic_id: str) -> bool:
+        """
+        Checks whether a certain comic is already in the list.
+
+        Args:
+            comic_id (str): The ID of the comic to check.
+
+        Returns:
+            bool: True if already in the list, False if not.
+        """
         for i in range(self.count()):
             if self.item(i).data(Qt.ItemDataRole.UserRole) == comic_id:
                 return True
         return False
 
     def startDrag(self, supportedActions) -> None:
+        """
+        Starts a drag action by encoding MIME data and creates a mini image
+        to follow the cursor.
+
+        The MIME data is a dictionary with keys, "comic_ids" and "positions", both
+        of which have values which are lists of ID's and position's respectively.
+        They are in the same order, so that the lists line out.
+
+        They are lists but there should only be one widget dragged at a time by the
+        user.
+        """
         items = self.selectedItems()
         if not items:
             return
@@ -205,6 +276,9 @@ class ReadingOrderList(QListWidget):
         drag.exec(Qt.DropAction.CopyAction)
 
     def dragEnterEvent(self, event) -> None:
+        """
+        Allows a drag action from this widget, or from the DraggableComicGridView.
+        """
         if event.mimeData().hasFormat(self.MIME_TYPE):
             event.acceptProposedAction()
         elif event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
@@ -213,6 +287,9 @@ class ReadingOrderList(QListWidget):
             event.ignore()
 
     def dragMoveEvent(self, event) -> None:
+        """
+        Allows a drag action from this widget, or from the DraggableComicGridView.
+        """
         if event.mimeData().hasFormat(self.MIME_TYPE):
             event.acceptProposedAction()
         elif event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
@@ -221,6 +298,14 @@ class ReadingOrderList(QListWidget):
             event.ignore()
 
     def dropEvent(self, event) -> None:
+        """
+        This is where the logic for the drop event is dispatched.
+
+        There are two paths, either the frop is from this widget,
+        or from the DraggableComicGridView. The former leads to a
+        re-ordering of the list and latter adds a comic into the
+        list.
+        """
         if event.mimeData().hasFormat(self.MIME_TYPE):
             data = event.mimeData().data(self.MIME_TYPE)
             payload = json.loads(bytes(data).decode())
@@ -247,9 +332,21 @@ class ReadingOrderList(QListWidget):
             for i in comic_ids:
                 self.add_comic(i, insert_row)
             event.acceptProposedAction()
+        else:
+            event.ignore()
 
     @staticmethod
     def get_comic_icon(image_path: Path) -> QPixmap:
+        """
+        Gets the image from a filepath and then scales it down
+        to fit inside the comic list widgets.
+
+        Args:
+            image_path (Path): The path of the image file.
+
+        Returns:
+            QPixmap: The QPixmap of the scaled image.
+        """
         pixmap = QPixmap(str(image_path))
         return pixmap.scaled(
             QSize(120, 160),
@@ -259,13 +356,27 @@ class ReadingOrderList(QListWidget):
 
 
 class ReadingOrderEditor(QWidget):
+    """
+    A class that represents an editor for a reading order.
+    Combining an ordered list of the current comics in the order
+    on the left and the full collection of comics in the library
+    on the right.
+
+    It is of QWidget type.
+    """
+
     def __init__(self, order_id: int, order_title: str):
+        """
+        Creates the main widget. Containing a splitter so that the
+        proportions of the different components can be adjusted.
+
+        Args:
+            order_id (int): The id of the reading order being edited.
+            order_title (str): The description of the reading order.
+        """
         super().__init__()
         self.order_id = order_id
         self.order_title = order_title
-
-        # self.setWindowTitle("Edit Reading Order")
-        # self.resize(1200, 800)
 
         dummy_layout = QHBoxLayout(self)
         # main_layout.setSpacing(12)
@@ -286,8 +397,8 @@ class ReadingOrderEditor(QWidget):
         dummy_layout.addWidget(self.splitter)
 
     def save_order(self):
+        """Saves the currently displayed reading order to the database."""
         order = self.order_panel.get_current_order()
-        # print("The current order is: ", order)
         with RepoWorker() as repo:
             repo.add_to_order(self.order_id, order)
 

--- a/reading_order_widget.py
+++ b/reading_order_widget.py
@@ -35,7 +35,7 @@ class ReadingOrderCreation(QDialog):
         reading order name and the other for the description.
         """
         super().__init__()
-
+        self.setWindowTitle("Reading order creation")
         self.main_display = QWidget()
         self.main_layout = QVBoxLayout(self.main_display)
 
@@ -71,13 +71,27 @@ class ReadingOrderCreation(QDialog):
         """
         name = self.textbox.text()
         description = self.textbox2.text()
+        if name == "":
+            self.show_error_message("Cannot have empty name.").exec()
+        else:
+            with RepoWorker() as worker:
+                if description == "":
+                    description = None
+                worker.create_reading_order(name, description)
 
-        with RepoWorker() as worker:
-            if description == "":
-                description = None
-            worker.create_reading_order(name, description)
+            self.close()
 
-        self.close()
+    @staticmethod
+    def show_error_message(message: str) -> QDialog:
+        error_dialog = QDialog()
+        error_dialog.setWindowTitle("Error!")
+        message_box = QLabel(message)
+        layout = QVBoxLayout(error_dialog)
+        layout.addWidget(message_box)
+        exit_button = QPushButton("Ok")
+        layout.addWidget(exit_button, alignment=Qt.AlignmentFlag.AlignBottom)
+        exit_button.clicked.connect(error_dialog.close)
+        return error_dialog
 
 
 class ReadingOrderList(QListWidget):
@@ -258,9 +272,8 @@ class ReadingOrderList(QListWidget):
             return
 
         ids = [item.data(Qt.ItemDataRole.UserRole) for item in items]
-        positions = []
-        for i in ids:
-            positions.append(self.get_position(i))
+        positions = [self.row(item) for item in items]
+
         payload = {"comic_ids": ids, "positions": positions}
 
         mime = QMimeData()
@@ -283,9 +296,9 @@ class ReadingOrderList(QListWidget):
         """
         Allows a drag action from this widget, or from the DraggableComicGridView.
         """
-        if event.mimeData().hasFormat(self.MIME_TYPE):
-            event.acceptProposedAction()
-        elif event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
+        if event.mimeData().hasFormat(self.MIME_TYPE) or event.mimeData().hasFormat(
+            DraggableComicGridView.MIME_TYPE
+        ):
             event.acceptProposedAction()
         else:
             event.ignore()
@@ -294,9 +307,9 @@ class ReadingOrderList(QListWidget):
         """
         Allows a drag action from this widget, or from the DraggableComicGridView.
         """
-        if event.mimeData().hasFormat(self.MIME_TYPE):
-            event.acceptProposedAction()
-        elif event.mimeData().hasFormat(DraggableComicGridView.MIME_TYPE):
+        if event.mimeData().hasFormat(self.MIME_TYPE) or event.mimeData().hasFormat(
+            DraggableComicGridView.MIME_TYPE
+        ):
             event.acceptProposedAction()
         else:
             event.ignore()
@@ -330,6 +343,8 @@ class ReadingOrderList(QListWidget):
             data = event.mimeData().data(DraggableComicGridView.MIME_TYPE)
             comic_ids = bytes(data.data()).decode().split(",")
             comic_ids = [str(i) for i in comic_ids]
+            if len(comic_ids) != 1:
+                return
             insert_row = self.indexAt(event.position().toPoint()).row()
             if insert_row < 0:
                 insert_row = self.count()
@@ -376,14 +391,13 @@ class ReadingOrderEditor(QWidget):
 
         Args:
             order_id (int): The id of the reading order being edited.
-            order_title (str): The description of the reading order.
+            order_title (str): The display name of the reading order.
         """
         super().__init__()
         self.order_id = order_id
         self.order_title = order_title
 
-        dummy_layout = QHBoxLayout(self)
-        # main_layout.setSpacing(12)
+        main_layout = QHBoxLayout()
         self.splitter = QSplitter()
         with RepoWorker() as worker:
             all_comics = worker.get_all_comics()
@@ -398,7 +412,9 @@ class ReadingOrderEditor(QWidget):
         self.save_button.clicked.connect(self.save_order)
         self.splitter.addWidget(self.left_widget)
         self.splitter.addWidget(self.library_panel)
-        dummy_layout.addWidget(self.splitter)
+        main_layout.addWidget(self.splitter)
+
+        self.setLayout(main_layout)
 
     def save_order(self):
         """Saves the currently displayed reading order to the database."""

--- a/rss/rss_repository.py
+++ b/rss/rss_repository.py
@@ -1,5 +1,6 @@
 import sqlite3
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 
@@ -11,7 +12,7 @@ class RSSRepository:
     RSS feed entries with automatic cleanup of old entries.
     """
 
-    def __init__(self, db_file: str) -> None:
+    def __init__(self, db_file: Path) -> None:
         """
         Initialise the RSS repository with a database connection.
 


### PR DESCRIPTION
Added a full fledged reading order editor with decent looking widgets which are draggable so the user can easily adjust an order.

The database logic was re-structured so that saving a reading order just completely overwrites the original instead of comparing two different lists and shifting down entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer reading-order editor: drag-and-drop reordering, add from library, duplicate prevention, and enforced non-empty order names.
  * New actions to delete entire collections or orders.

* **Refactor**
  * Sidebar collapse/restore and layout clearing improved for smoother navigation.
  * Reading-order saves now replace orders atomically; grid/list reloads are more reliable.

* **Other**
  * Database file path is configurable via environment variable; local cache directory ignored.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CloakedLeader/comic_library/pull/64)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->