### PR TITLE
Reader improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ log.txt
 quick.py
 missing_stubs
 .mypy_cache/
+*.svg

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,5 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python-envs.defaultEnvManager": "ms-python.python:system",
+    "svg.preview.background": "custom",
 }

--- a/database/gui_repo_worker.py
+++ b/database/gui_repo_worker.py
@@ -233,6 +233,12 @@ class RepoWorker:
                 (primary_key, last_page, 0),
             )
 
+    def remove_from_reading_progress(self, primary_key: str) -> None:
+        """Removes the comic from reading progress table."""
+        self.cursor.execute(
+            "DELETE FROM reading_progress WHERE comic_id = ?", (primary_key,)
+        )
+
     def mark_as_finished(self, primary_key: str, last_page: int) -> None:
         """
         Changes the status of a comic from not finished to finished.

--- a/reader.py
+++ b/reader.py
@@ -1002,8 +1002,30 @@ class SimpleReader(QMainWindow):
         """
         if isinstance(pixmap, QPixmap):
             final = pixmap
+            final = pixmap.scaled(
+                self.image_label.width(),
+                self.image_label.height(),
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
         else:
             left, right = pixmap
+            page_width = max(1, self.image_label.width() // 2)
+            page_height = self.image_label.height()
+
+            left = left.scaled(
+                page_width,
+                page_height,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+
+            right = right.scaled(
+                page_width,
+                page_height,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
 
             width = left.width() + right.width()
             height = max(left.height(), right.height())
@@ -1012,14 +1034,11 @@ class SimpleReader(QMainWindow):
             final.fill(Qt.GlobalColor.transparent)
 
             painter = QPainter(final)
-            painter.drawPixmap(0, 0, left)
-            painter.drawPixmap(left.width(), 0, right)
+            painter.drawPixmap(0, (height - left.height()) // 2, left)
+            painter.drawPixmap(left.width(), (height - right.height()) // 2, right)
             painter.end()
 
-        scaled = final.scaledToHeight(
-            self.image_label.height(), Qt.TransformationMode.SmoothTransformation
-        )
-        self.image_label.setPixmap(scaled)
+        self.image_label.setPixmap(final)
         # self.page_label.setText(f"Page {index + 1} / {self.comic.total_pages}")
 
     def on_page_ready(self, index: int):

--- a/reader.py
+++ b/reader.py
@@ -690,7 +690,7 @@ class PagePreloader(QObject):
         self.pool = QThreadPool()
         self.pool.setMaxThreadCount(6)
 
-    def get_load_order(self, index: int) -> list[int]:
+    def get_load_order(self, indices: tuple[int, ...]) -> list[int]:
         """
         Orders the list of pages to be loaded into the correct order,
         with the highest priority loads first.
@@ -702,22 +702,21 @@ class PagePreloader(QObject):
             list[int]: The ordered list of indices for the next pages to be read.
             They are ordered with descending priority.
         """
-        pages = []
-        pages.append(index)
+        pages = list(indices)
 
         for offset in range(1, self.forward_buff + 1):
-            page = index + offset
+            page = indices[-1] + offset
             if page < self.comic.total_pages:
                 pages.append(page)
 
         for offset in range(1, self.backward_buff + 1):
-            page = index - offset
+            page = indices[0] - offset
             if page >= 0:
                 pages.append(page)
 
         return pages
 
-    def preload(self, index: int) -> None:
+    def preload(self, indices: tuple[int, ...]) -> None:
         """
         Preload pages surrounding the current reading position.
 
@@ -734,7 +733,7 @@ class PagePreloader(QObject):
             - Cache eviction occurs immediately for pages outside
             the preload window.
         """
-        load_order = self.get_load_order(index)
+        load_order = self.get_load_order(indices)
         wanted = set(load_order)
         self.wanted = wanted
 
@@ -993,14 +992,12 @@ class SimpleReader(QMainWindow):
         task is scheduled which displays the image once completed.
         """
         display = self.sequence.current_display()
-        failed = False
-        for page_index in display:
-            if page_index not in self.preloader.image_cache:
-                self.image_label.setText("Loading...")
-                self.preloader.preload(page_index)
-                failed = True
-        if failed:
+        self.preloader.preload(display)
+        missing = [p for p in display if p not in self.preloader.image_cache]
+        if missing:
+            self.image_label.setText("Loading...")
             return
+
         if len(display) == 1:
             self.render_pixmap(self.preloader.image_cache[display[0]])
         else:
@@ -1135,6 +1132,11 @@ class SimpleReader(QMainWindow):
         else:
             return
 
+    def resizeEvent(self, event) -> None:
+        """Redraws pixmap upon window resize."""
+        super().resizeEvent(event)
+        self.display_current_page()
+
     def set_one_page(self) -> None:
         """Sets the reading mode to single-page and refreshes the display."""
         self.sequence.set_mode(ReadMode.SINGLE_PAGE)
@@ -1152,6 +1154,7 @@ class SimpleReader(QMainWindow):
         This is used by the reading controller for memory and resource
         management.
         """
+        self.preloader.pool.clear()
         self.closed.emit(self.comic.id, self.sequence.position_to_archive_index())
         super().closeEvent(event)
 

--- a/reader.py
+++ b/reader.py
@@ -290,6 +290,7 @@ class ReadingSequence(QObject):
         Args:
             comic (Comic): The data of the Comic to be read.
         """
+        super().__init__()
         self.comic = comic
         self.mode = ReadMode.SINGLE_PAGE
 

--- a/reader.py
+++ b/reader.py
@@ -666,6 +666,7 @@ class PagePreloader(QObject):
     """
 
     page_ready = Signal(int)
+    page_failed = Signal(int, str)
 
     def __init__(self, comic: Comic):
         """
@@ -684,6 +685,7 @@ class PagePreloader(QObject):
         self.pending: list[int] = []
         self.loading: set[int] = set()
         self.wanted: set[int] = set()
+        self.failed: set[int] = set()
 
         self.pool = QThreadPool()
         self.pool.setMaxThreadCount(6)
@@ -819,10 +821,18 @@ class PagePreloader(QObject):
         Failed pages are not automatically retried.
         """
         self.loading.discard(index)
-        print(f"[ERROR] Failed to load page {index}: {message}")
+        logging.error(
+            "Failed to load page %d (%s): %s",
+            index,
+            self.comic.pages[index].filename,
+            message,
+        )
+        self.failed.add(index)
+        self.page_failed.emit(index, message)
+        self.fill_workers()
+
         # TODO: Add retry method for pages that fail to load.
-        # Need to implement some kind of diagnostic,
-        # or at the minimum flag error to the user.
+        # Need to implement some kind of diagnostic
 
 
 class Navigation(QDialog):

--- a/reader.py
+++ b/reader.py
@@ -657,12 +657,11 @@ class Navigation(QDialog):
             self.error_message.setText("Please enter a number.")
             return
 
-        page_num = int(self.text)
-        if 0 < page_num < self.max_pages:
+        if 0 <= page_num <= self.max_pages:
             self.accept()
         else:
             self.error_message.setText(
-                f"Please enter a number between 0 and {self.max_pages}."
+                f"Please enter a number between 1 and {self.max_pages - 1}."
             )
             return
 

--- a/reader.py
+++ b/reader.py
@@ -33,6 +33,7 @@ from PySide6.QtGui import (
     QPainter,
     QPixmap,
     QShortcut,
+    QWheelEvent,
 )
 from PySide6.QtWidgets import (
     QDialog,
@@ -89,7 +90,6 @@ class PageInfo:
     filename: str
     index: int
     page_type: PageType = PageType.UNKNOWN
-    analysed: bool = False
 
 
 @dataclass(slots=True)
@@ -202,7 +202,7 @@ class Comic:
         size = reader.size()
         return size.width(), size.height()
 
-    def analyse_page(self, page) -> PageInfo:
+    def analyse_page(self, page: PageInfo) -> PageInfo:
         if page.page_type != PageType.UNKNOWN:
             return page
 
@@ -824,6 +824,15 @@ class SimpleReader(QMainWindow):
         elif key == Qt.Key.Key_Left:
             self.prev_page()
 
+    def wheelEvent(self, event: QWheelEvent) -> None:
+        angle = event.angleDelta().y()
+        if angle > 0:
+            self.next_page()
+        elif angle < 0:
+            self.prev_page()
+        else:
+            return
+
     def set_one_page(self) -> None:
         self.read_mode = ReadMode.SINGLE_PAGE
         self.preloader.wait_for_spread = False
@@ -843,6 +852,7 @@ class SimpleReader(QMainWindow):
         This is used by the reading controller for memory and resource
         management.
         """
+        self.update_index()
         self.closed.emit(self.comic.id, self.current_index)
         super().closeEvent(event)
 

--- a/reader.py
+++ b/reader.py
@@ -696,7 +696,7 @@ class PagePreloader(QObject):
         with the highest priority loads first.
 
         Args:
-            index (int): The index of the next page to be read.
+            indices (tuple[int, ...]): The indices of the current display pages.
 
         Returns:
             list[int]: The ordered list of indices for the next pages to be read.
@@ -724,7 +724,7 @@ class PagePreloader(QObject):
         inside the range are added to the pending list.
 
         Args:
-            current_index (int): Current page index around which
+            indices (tuple[int, ...]): Current display page indices around which
             preloading should occur.
 
         Notes:
@@ -740,8 +740,6 @@ class PagePreloader(QObject):
         for idx in list(self.image_cache):
             if idx not in wanted:
                 del self.image_cache[idx]
-
-        self.pending.clear()
 
         self.pending = [
             page

--- a/reader.py
+++ b/reader.py
@@ -194,8 +194,10 @@ class Comic:
 
     def image_size(self, index: int) -> tuple[int, int]:
         page = self.pages[index]
-        image_bytes = self.zip.read(page.filename)
-
+        try:
+            image_bytes = self.zip.read(page.filename)
+        except Exception as e:
+            raise ImageLoadError(f"Failed to read image {page.filename}: {e}") from e
         buffer = QBuffer()
         buffer.setData(QByteArray(image_bytes))
         buffer.open(QIODevice.OpenModeFlag.ReadOnly)
@@ -208,12 +210,20 @@ class Comic:
         if page.page_type != PageType.UNKNOWN:
             return page
 
-        width, height = self.image_size(page.index)
-        page.page_type = PageType.SPREAD if width / height > 1.3 else PageType.NORMAL
+        try:
+            width, height = self.image_size(page.index)
+            page.page_type = (
+                PageType.SPREAD if width / height > 1.3 else PageType.NORMAL
+            )
+        except ImageLoadError:
+            page.page_type = PageType.NORMAL
         return page
 
 
-class ReadingSequence:
+class ReadingSequence(QObject):
+    front_cover_reached = Signal()
+    back_cover_reached = Signal()
+
     def __init__(self, comic: Comic):
         self.comic = comic
         self.mode = ReadMode.SINGLE_PAGE
@@ -255,9 +265,6 @@ class ReadingSequence:
         while i < self.comic.total_pages:
             display = self.build_display_page(i)
             pages.append(display)
-            pos = len(pages) - 1
-            for page in display.pages:
-                self.page_to_position[page] = pos
 
             if len(display.pages) == 2:
                 i += 2
@@ -305,10 +312,17 @@ class ReadingSequence:
         return display.pages[0]
 
     def next(self):
-        self.position += 1
+        if self.position < len(self.display_pages) - 1:
+            self.position += 1
+        else:
+            print("Comic finished :(")
+            self.back_cover_reached.emit()
 
     def prev(self):
-        self.position -= 1
+        if self.position > 0:
+            self.position -= 1
+        else:
+            self.front_cover_reached.emit()
 
     def current_display(self) -> tuple[int, ...]:
         return self.display_pages[self.position].pages
@@ -621,17 +635,36 @@ class Navigation(QDialog):
 
         layout = QVBoxLayout(self)
         instruct = QLabel(f"Enter page to navigate to. ({max_pages} pages)")
+        self.max_pages = max_pages
         self.line_edit = QLineEdit()
-        self.line_edit.returnPressed.connect(self.accept)
+        self.line_edit.returnPressed.connect(self.ok_pressed)
+        self.error_message = QLabel("")
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
 
-        buttons.accepted.connect(self.accept)
+        buttons.accepted.connect(self.ok_pressed)
         buttons.rejected.connect(self.reject)
         layout.addWidget(instruct)
         layout.addWidget(self.line_edit)
+        layout.addWidget(self.error_message)
         layout.addWidget(buttons)
+
+    def ok_pressed(self):
+        try:
+            page_num = int(self.text)
+        except ValueError:
+            self.error_message.setText("Please enter a number.")
+            return
+
+        page_num = int(self.text)
+        if 0 < page_num < self.max_pages:
+            self.accept()
+        else:
+            self.error_message.setText(
+                f"Please enter a number between 0 and {self.max_pages}."
+            )
+            return
 
     @property
     def text(self) -> str:
@@ -651,7 +684,6 @@ class SimpleReader(QMainWindow):
     """
 
     closed = Signal(str, int)
-    page_changed = Signal(str, int)
 
     def __init__(self, comic: Comic):
         """
@@ -668,8 +700,8 @@ class SimpleReader(QMainWindow):
         super().__init__()
 
         self.comic = comic
-        self.sequence = ReadingSequence(comic)
 
+        self.sequence = ReadingSequence(comic)
         self.preloader = PagePreloader(comic)
         self.preloader.page_ready.connect(self.on_page_ready)
         self.preloader.spread_ready.connect(self.on_page_ready)

--- a/reader.py
+++ b/reader.py
@@ -681,6 +681,7 @@ class PagePreloader(QObject):
         self.backward_buff = 4
 
         self.image_cache: dict[int, QPixmap] = {}
+        self.pending: list[int] = []
         self.loading: set[int] = set()
 
         self.pool = QThreadPool()
@@ -731,19 +732,28 @@ class PagePreloader(QObject):
             the preload window.
         """
         load_order = self.get_load_order(index)
-
         wanted = set(load_order)
 
         for idx in list(self.image_cache):
             if idx not in wanted:
                 del self.image_cache[idx]
 
-        for priority, idx in enumerate(reversed(load_order)):
-            if idx in self.image_cache or idx in self.loading:
-                continue
-            self.schedule_load(idx, priority)
+        self.pending.clear()
 
-    def schedule_load(self, index: int, priority: int = 0):
+        self.pending = [
+            page
+            for page in load_order
+            if page not in self.loading and page not in self.image_cache
+        ]
+
+        self.fill_workers()
+
+    def fill_workers(self):
+        while len(self.loading) < self.pool.maxThreadCount() and self.pending:
+            page = self.pending.pop(0)
+            self.schedule_load(page)
+
+    def schedule_load(self, index: int):
         """
         Schedule asynchronous loading of a page image.
 
@@ -766,7 +776,7 @@ class PagePreloader(QObject):
         task.signals.finished.connect(self.on_loaded)
         task.signals.error.connect(self.on_error)
 
-        self.pool.start(task, priority)
+        self.pool.start(task)
 
     def on_loaded(self, index: int, pixmap: QPixmap):
         """
@@ -784,8 +794,10 @@ class PagePreloader(QObject):
                 Emitted after the image has been stored in the cache.
         """
         self.loading.discard(index)
+
         self.image_cache[index] = pixmap
         self.page_ready.emit(index)
+        self.fill_workers()
 
     def on_error(self, index: int, message: str):
         """

--- a/reader.py
+++ b/reader.py
@@ -335,6 +335,9 @@ class ReadingSequence(QObject):
             case ReadMode.MANGA:
                 self.display_pages = self.build_manga()
 
+            case ReadMode.INFINITY:
+                raise NotImplementedError("Infinity reading mode is not implemented.")
+
         for pos, display in enumerate(self.display_pages):
             for page in display.pages:
                 self.page_to_position[page] = pos

--- a/reader.py
+++ b/reader.py
@@ -35,9 +35,13 @@ from PySide6.QtGui import (
     QShortcut,
 )
 from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
     QLabel,
+    QLineEdit,
     QMainWindow,
     QToolBar,
+    QVBoxLayout,
 )
 
 from classes.helper_classes import GUIComicInfo
@@ -558,6 +562,29 @@ class PagePreloader(QObject):
         # or at the minimum flag error to the user.
 
 
+class Navigation(QDialog):
+    def __init__(self, max_pages: int):
+        super().__init__()
+
+        layout = QVBoxLayout(self)
+        instruct = QLabel(f"Enter page to navigate to. ({max_pages} pages)")
+        self.line_edit = QLineEdit()
+        self.line_edit.returnPressed.connect(self.accept)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(instruct)
+        layout.addWidget(self.line_edit)
+        layout.addWidget(buttons)
+
+    @property
+    def text(self) -> str:
+        return self.line_edit.text()
+
+
 class SimpleReader(QMainWindow):
     """
     The main reading window.
@@ -612,6 +639,9 @@ class SimpleReader(QMainWindow):
             QIcon(str(IMAGES / "arrow_right.svg")), "", self.next_page
         )
         self.next_action.setToolTip("Next Page")
+        self.toolbar.addAction(
+            QIcon(str(IMAGES / "search.svg")), "", self.page_navigation
+        )
         self.toolbar.addAction(QIcon(str(IMAGES / "zoom_in.svg")), "")
         self.toolbar.addAction(QIcon(str(IMAGES / "zoom_out.svg")), "")
         self.toolbar.addAction(QIcon(str(IMAGES / "bookmark_add.svg")), "")
@@ -815,3 +845,12 @@ class SimpleReader(QMainWindow):
         """
         self.closed.emit(self.comic.id, self.current_index)
         super().closeEvent(event)
+
+    def page_navigation(self) -> None:
+        dialog = Navigation(self.comic.total_pages)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            self.current_index = int(dialog.text)
+            self.sequence.update_position(self.current_index)
+            self.display_current_page()
+        else:
+            return

--- a/reader.py
+++ b/reader.py
@@ -683,6 +683,7 @@ class PagePreloader(QObject):
         self.image_cache: dict[int, QPixmap] = {}
         self.pending: list[int] = []
         self.loading: set[int] = set()
+        self.wanted: set[int] = set()
 
         self.pool = QThreadPool()
         self.pool.setMaxThreadCount(6)
@@ -690,7 +691,7 @@ class PagePreloader(QObject):
     def get_load_order(self, index: int) -> list[int]:
         """
         Orders the list of pages to be loaded into the correct order,
-        so that the priority system loads the most important first.
+        with the highest priority loads first.
 
         Args:
             index (int): The index of the next page to be read.
@@ -719,7 +720,7 @@ class PagePreloader(QObject):
         Preload pages surrounding the current reading position.
 
         Pages outside the desired range are evicted, and missing pages
-        inside the range are scheduled for asynchronous loading.
+        inside the range are added to the pending list.
 
         Args:
             current_index (int): Current page index around which
@@ -727,12 +728,13 @@ class PagePreloader(QObject):
 
         Notes:
             - Already cached pages are reused.
-            - Pages currently loaded are not scheduled again.
+            - Pages currently loading are not scheduled again.
             - Cache eviction occurs immediately for pages outside
             the preload window.
         """
         load_order = self.get_load_order(index)
         wanted = set(load_order)
+        self.wanted = wanted
 
         for idx in list(self.image_cache):
             if idx not in wanted:
@@ -749,6 +751,10 @@ class PagePreloader(QObject):
         self.fill_workers()
 
     def fill_workers(self):
+        """
+        Ensures that all workers in the Pool have a task, provided there are tasks
+        to complete.
+        """
         while len(self.loading) < self.pool.maxThreadCount() and self.pending:
             page = self.pending.pop(0)
             self.schedule_load(page)
@@ -762,9 +768,6 @@ class PagePreloader(QObject):
 
         Args:
             index (int): Page index to load.
-            priority (int): The priority with which to add the task
-            to the scheduler, higher priorities are loaded first. Defaults
-            to 0.
 
         Notes:
             The page index is added to ``loading`` immediately to prevent
@@ -782,21 +785,23 @@ class PagePreloader(QObject):
         """
         Handle successful completion of an image loading task.
 
-        The loaded pixmap is inserted into the cache and the page is
-        marked as no longer loading.
+        The index of the loaded pixmap is checked to ensure it is
+        still wanted, then it's inserted into the cache and the page
+        is marked as no longer loading.
 
         Args:
             index (int): Index of the loaded page.
             pixmap (QPixmap): Loaded page image.
 
         Emits:
-            page_ready:
-                Emitted after the image has been stored in the cache.
+            page_ready: Emitted after the image has been stored
+            in the cache.
         """
         self.loading.discard(index)
 
-        self.image_cache[index] = pixmap
-        self.page_ready.emit(index)
+        if index in self.wanted:
+            self.image_cache[index] = pixmap
+            self.page_ready.emit(index)
         self.fill_workers()
 
     def on_error(self, index: int, message: str):

--- a/reader.py
+++ b/reader.py
@@ -1,6 +1,7 @@
 """
-A collection of classes for reading comics and preloading images so reading
-is snappy and responsive.
+A collection of classes for reading comics, preloading images, managing the order
+of the comic images, so reading is snappy, responsive and the code structure is
+expandable and future-proof.
 """
 
 import logging
@@ -73,6 +74,11 @@ class ImageLoadError(ComicError):
 
 
 class ReadMode(Enum):
+    """
+    Enum for the current mode of reading. This affects the layout of the pages,
+    and the behaviour of the forward and backward buttons.
+    """
+
     SINGLE_PAGE = auto()
     DOUBLE_PAGE = auto()
     MANGA = auto()
@@ -80,6 +86,11 @@ class ReadMode(Enum):
 
 
 class PageType(Enum):
+    """
+    An Enum containing the diferent kinds of pages that would exist within a
+    comic archive. These are used for the logic within the comic page sequence.
+    """
+
     UNKNOWN = auto()
     COVER = auto()
     BACK_COVER = auto()
@@ -89,6 +100,10 @@ class PageType(Enum):
 
 @dataclass(slots=True)
 class PageInfo:
+    """
+    A data class for storing key information on comic pages within an archive.
+    """
+
     filename: str
     index: int
     page_type: PageType = PageType.UNKNOWN
@@ -96,6 +111,11 @@ class PageInfo:
 
 @dataclass(slots=True)
 class DisplayPage:
+    """
+    A data class for storing the pages indices within a 'page'
+    displayed to the user.
+    """
+
     pages: tuple[int, ...]
 
 
@@ -193,6 +213,22 @@ class Comic:
         return self.get_image_data(self.current_index)
 
     def image_size(self, index: int) -> tuple[int, int]:
+        """
+        Gets the size of an image within the comic archive.
+
+        Reads the image data via QBuffer in read-only mode and then analyses
+        the header to get the size.
+
+        Args:
+            index (int): The index of the comic image to anaylse, the indices
+            are taken from the order of pages in the comic archive.
+
+        Raises:
+            ImageLoadError: Raised if the image bytes cannot be read.
+
+        Returns:
+            tuple[int, int]: The image size in (width, height) format.
+        """
         page = self.pages[index]
         try:
             image_bytes = self.zip.read(page.filename)
@@ -207,6 +243,18 @@ class Comic:
         return size.width(), size.height()
 
     def analyse_page(self, page: PageInfo) -> PageInfo:
+        """
+        Decides the kind of page that the image is by looking at the size.
+
+        Then edits the `page_type` attribute of the `PageInfo` in place depending
+        on the aspect ratio of the image.
+
+        Args:
+            page (PageInfo): The PageInfo object belong to the comic image to look at.
+
+        Returns:
+            PageInfo: The edited PageInfo object with its `page_type` updated.
+        """
         if page.page_type != PageType.UNKNOWN:
             return page
 
@@ -221,13 +269,29 @@ class Comic:
 
 
 class ReadingSequence(QObject):
+    """
+    A class to manage the order of comic display images.
+
+    The order depends on the reading type.
+    """
+
     front_cover_reached = Signal()
     back_cover_reached = Signal()
 
     def __init__(self, comic: Comic):
+        """
+        Creates the sequence in single page mode as default.
+
+        Creates the list `self.display_pages` the contains the order of the comic
+        images to display.
+        Creates the dictionary `self.page_to_position` to track the relationship between
+        index number and page number.
+
+        Args:
+            comic (Comic): The data of the Comic to be read.
+        """
         self.comic = comic
         self.mode = ReadMode.SINGLE_PAGE
-        self.position = 0
 
         self.display_pages: list[DisplayPage] = []
         self.page_to_position: dict[int, int] = {}
@@ -235,7 +299,16 @@ class ReadingSequence(QObject):
         self.build_sequence()
         self.position = self.archive_index_to_position(comic.current_index)
 
-    def set_mode(self, mode: ReadMode):
+    def set_mode(self, mode: ReadMode) -> None:
+        """
+        Rebuilds the reading sequence depending on the inputted reading mode.
+
+        The index number is recorded and then the new page number in the new sequence
+        is updated to match the last seen comic image.
+
+        Args:
+            mode (ReadMode): The reading mode that dictates the layout of the pages
+        """
         current_archive_page = self.current_display()[0]
 
         self.mode = mode
@@ -243,7 +316,14 @@ class ReadingSequence(QObject):
 
         self.position = self.archive_index_to_position(current_archive_page)
 
-    def build_sequence(self):
+    def build_sequence(self) -> None:
+        """
+        A helper function which decides the correct way to rebuild the sequence
+        by looking at the `self.mode` attribute.
+
+        Once the sequence is rebuilt, the `self.page_to_position` dictionary is also
+        rebuilt to match the new sequence.
+        """
         self.page_to_position.clear()
         match self.mode:
             case ReadMode.SINGLE_PAGE:
@@ -260,6 +340,14 @@ class ReadingSequence(QObject):
                 self.page_to_position[page] = pos
 
     def build_double(self) -> list[DisplayPage]:
+        """
+        Loops through the PageInfo's in self.comic and uses its `page_type`
+        to decide whether the image should be shown in double-page or single-page.
+
+        Returns:
+            list[DisplayPage]: The new display sequence containing an ordered list
+            of DisplayPage's.
+        """
         pages = []
         i = 0
         while i < self.comic.total_pages:
@@ -274,12 +362,47 @@ class ReadingSequence(QObject):
         return pages
 
     def build_single(self) -> list[DisplayPage]:
+        """
+        Creates the sequence for single-page reading mode.
+
+        This just creates a DisplayPage instance for each image in the comic
+        archive.
+
+        Returns:
+            list[DisplayPage]: Ordered list of display pages.
+        """
         return [DisplayPage((page.index,)) for page in self.comic.pages]
 
     def build_manga(self) -> list[DisplayPage]:
+        """
+        Creates the sequence for manga reading mode.
+
+        It builds the single-page mode and then reverses it so that the archive is
+        read right-to-left.
+
+        Returns:
+            list[DisplayPage]: Ordered list of display pages.
+        """
         return list(reversed(self.build_single()))
 
     def build_display_page(self, index: int) -> DisplayPage:
+        """
+        Creates a DisplayPage for a given image in the comic archive.
+
+        Uses the `page_type` attribute or the position within the archive to decide
+        how to display to the user.
+
+        This is only used when building the double-page sequence.
+
+        Args:
+            index (int): The position of the comic image within the comic archive.
+
+        Raises:
+            ValueError: If the PageInfo has its `page_type` as UNKNOWN.
+
+        Returns:
+            DisplayPage: The DisplayPage that has the correct comic image indices.
+        """
         page = self.comic.pages[index]
 
         if page.page_type in (PageType.COVER, PageType.BACK_COVER):
@@ -302,29 +425,66 @@ class ReadingSequence(QObject):
         return DisplayPage((index, index + 1))
 
     def archive_index_to_position(self, index: int) -> int:
+        """
+        Gets the position in the ordered list of DisplayPages from
+        the image index in the comic archive.
+
+        Args:
+            index (int): The index of the image in the archive.
+
+        Returns:
+            int: The position in the Display order.
+        """
         return self.page_to_position[index]
 
     def update_position(self, index: int):
+        """
+        Updates the current position of the sequence.
+
+        Args:
+            index (int): The index of the image in the archive.
+        """
         self.position = self.archive_index_to_position(index)
 
     def position_to_archive_index(self) -> int:
+        """
+        Gets the index of the image in the archive from the position in
+        the DisplayPage sequence.
+
+        Returns:
+            int: Index of the comic image in the archive.
+        """
         display = self.display_pages[self.position]
         return display.pages[0]
 
     def next(self):
+        """
+        Increases the position counter by one if there are more pages
+        to be read. Otherwise, emits the back cover signal.
+        """
         if self.position < len(self.display_pages) - 1:
             self.position += 1
         else:
-            print("Comic finished :(")
             self.back_cover_reached.emit()
 
     def prev(self):
+        """
+        Decreases the position counter by one if there are pages behind
+        the current one. Otherwise emits the front cover signal.
+        """
         if self.position > 0:
             self.position -= 1
         else:
             self.front_cover_reached.emit()
 
     def current_display(self) -> tuple[int, ...]:
+        """
+        Gets the current DisplayPage to send to the reader.
+
+        Returns:
+            tuple[int, ...]: A tuple of the comic image indices to include
+            in the view. Should have a maximum length of two.
+        """
         return self.display_pages[self.position].pages
 
 
@@ -469,9 +629,14 @@ class PagePreloader(QObject):
         comic (Comic):
             Comic source used to retrieve page image data.
 
-        buffer (int):
-            Number of pages before and after the current page that should
-            remain preloaded.
+        forward_buff (int):
+            Number of pages after the current page that should be
+            preloaded. This is larger since the chance is that people
+            would need to read forward than go back.
+
+        backward_buff (int):
+            Number of pages before the current page that should be
+            preloaded.
 
         image_cache (dict[int, QPixmap]):
             In-memory cache mapping page indices to loaded pixmaps.
@@ -491,11 +656,12 @@ class PagePreloader(QObject):
     Threading:
         Image loading occurs on worker threads managed by the internal
         thread pool, while cache updates and signal emissions occur
-        safely through Qt's signal-slot system.
+        safely through Qt's signal-slot system. There is a priority system
+        in place to ensure that the direct next pages are loaded first before
+        others for a smoother reading experience.
     """
 
     page_ready = Signal(int)
-    spread_ready = Signal(int)
 
     def __init__(self, comic: Comic):
         """
@@ -503,8 +669,6 @@ class PagePreloader(QObject):
 
         Args:
             comic (Comic): Comic source for page image retrieval.
-            buffer (int, optional): Number of pages before and after the
-            current page that should remain cached and preloaded. Defaults to 8.
         """
         super().__init__()
         self.comic = comic
@@ -514,12 +678,22 @@ class PagePreloader(QObject):
 
         self.image_cache: dict[int, QPixmap] = {}
         self.loading: set[int] = set()
-        self.wait_for_spread: bool = False
 
         self.pool = QThreadPool()
         self.pool.setMaxThreadCount(6)
 
     def get_load_order(self, index: int) -> list[int]:
+        """
+        Orders the list of pages to be loaded into the correct order,
+        so that the priority system loads the most important first.
+
+        Args:
+            index (int): The index of the next page to be read.
+
+        Returns:
+            list[int]: The ordered list of indices for the next pages to be read.
+            They are ordered with descending priority.
+        """
         pages = []
         pages.append(index)
 
@@ -539,10 +713,8 @@ class PagePreloader(QObject):
         """
         Preload pages surrounding the current reading position.
 
-        This method determines which pages should remain based on
-        the configured buffer size. Pages outside the desired range
-        are evicted, and missing pages inside the range are scheduled
-        for asynchronous loading.
+        Pages outside the desired range are evicted, and missing pages
+        inside the range are scheduled for asynchronous loading.
 
         Args:
             current_index (int): Current page index around which
@@ -576,6 +748,9 @@ class PagePreloader(QObject):
 
         Args:
             index (int): Page index to load.
+            priority (int): The priority with which to add the task
+            to the scheduler, higher priorities are loaded first. Defaults
+            to 0.
 
         Notes:
             The page index is added to ``loading`` immediately to prevent
@@ -630,7 +805,17 @@ class PagePreloader(QObject):
 
 
 class Navigation(QDialog):
+    """
+    A popup window for asking the user which page to navigate to.
+    """
+
     def __init__(self, max_pages: int):
+        """
+        Creates the instance variables like the line edit.
+
+        Args:
+            max_pages (int): The number of pages in the comic.
+        """
         super().__init__()
 
         layout = QVBoxLayout(self)
@@ -650,7 +835,13 @@ class Navigation(QDialog):
         layout.addWidget(self.error_message)
         layout.addWidget(buttons)
 
-    def ok_pressed(self):
+    def ok_pressed(self) -> None:
+        """
+        Checks that the entered value is first a number, and second within
+        the correct range.
+
+        If not, a suggestive error message is displayed to the user.
+        """
         try:
             page_num = int(self.text)
         except ValueError:
@@ -667,6 +858,9 @@ class Navigation(QDialog):
 
     @property
     def text(self) -> str:
+        """
+        Returns the text in the line edit.
+        """
         return self.line_edit.text()
 
 
@@ -689,8 +883,7 @@ class SimpleReader(QMainWindow):
         Creates the base window by opening the comic on the currenly read index
         and loading a certain amount of images before and after.
 
-        Creates toolbars for comic navigation and commenting. These are not yet
-        plugged into any slots.
+        Creates a toolbar for comic navigation and commenting.
 
         Args:
             comic (Comic): An instance of the :class`Comic` that gives useful data
@@ -703,7 +896,6 @@ class SimpleReader(QMainWindow):
         self.sequence = ReadingSequence(comic)
         self.preloader = PagePreloader(comic)
         self.preloader.page_ready.connect(self.on_page_ready)
-        self.preloader.spread_ready.connect(self.on_page_ready)
 
         self.setWindowTitle("Comic Reader")
 
@@ -753,6 +945,9 @@ class SimpleReader(QMainWindow):
         self.display_current_page()
 
     def toggle_fullscreen(self) -> None:
+        """
+        Toggles fullscreen mode.
+        """
         if self.isFullScreen():
             self.showMaximized()
         else:
@@ -760,7 +955,7 @@ class SimpleReader(QMainWindow):
 
     def display_current_page(self) -> None:
         """
-        Displays the page with index `self.current_index`.
+        Displays the current page by quering the sequence.
 
         If already in the image cache the image is loaded, otherwise
         a blank grey image with 'Loading...' is displayed and a
@@ -786,19 +981,24 @@ class SimpleReader(QMainWindow):
             )
 
     @overload
-    def render_pixmap(self, pixmap: QPixmap) -> None: ...
+    def render_pixmap(self, pixmap: QPixmap) -> None:
+        """
+        Renders a single image as the page for the reader.
+        """
+        ...
 
     @overload
-    def render_pixmap(self, pixmap: tuple[QPixmap, QPixmap]) -> None: ...
+    def render_pixmap(self, pixmap: tuple[QPixmap, QPixmap]) -> None:
+        """
+        Stiches together two images to display a double-page to the reader.
+        """
+        ...
 
     def render_pixmap(self, pixmap: QPixmap | tuple[QPixmap, QPixmap]) -> None:
         """
         Scales the pixmap taken from the image file into the right size and then
-        displays it, finally updates the displayed page number.
-
-        Args:
-            index (int): The zero-indexed index of the page to scale and load around.
-            pixmap (QPixmap): The QPixmap of the image to be displayed.
+        displays it, finally updates the displayed page number. Stitching together two
+        images if required.
         """
         if isinstance(pixmap, QPixmap):
             final = pixmap
@@ -826,8 +1026,8 @@ class SimpleReader(QMainWindow):
         """
         Activated when the preloader loads an image.
 
-        Sets the current index to the loaded image index and renders
-        the image.
+        Checks that the loaded page is still needed for the view, and then
+        calls the render function.
 
         Args:
             index (int): The index of the page just loaded by the preloader.
@@ -845,7 +1045,7 @@ class SimpleReader(QMainWindow):
         """
         Moves the reader to the next page.
 
-        Increases the `self.current_index` by 1 and then calls the function to display
+        Tells the sequence to advance by 1 and then calls the function to display
         the current page.
         """
         self.sequence.next()
@@ -855,7 +1055,7 @@ class SimpleReader(QMainWindow):
         """
         Moves the reader to the previous page.
 
-        Decreases the `self.current_index` by 1 and then calls the function to display
+        Tells the sequence to go back by 1 and then calls the function to display
         the current page.
         """
         self.sequence.prev()
@@ -873,6 +1073,10 @@ class SimpleReader(QMainWindow):
             self.prev_page()
 
     def wheelEvent(self, event: QWheelEvent) -> None:
+        """
+        Listens for scroll wheel events from the mouse and connects these to
+        the previous and next page functions.
+        """
         angle = event.angleDelta().y()
         if angle > 0:
             self.next_page()
@@ -882,10 +1086,12 @@ class SimpleReader(QMainWindow):
             return
 
     def set_one_page(self) -> None:
+        """Sets the reading mode to single-page and refreshes the display."""
         self.sequence.set_mode(ReadMode.SINGLE_PAGE)
         self.display_current_page()
 
     def set_double_page(self) -> None:
+        """Sets the reading mode to double-page and refreshes the display."""
         self.sequence.set_mode(ReadMode.DOUBLE_PAGE)
         self.display_current_page()
 
@@ -900,6 +1106,10 @@ class SimpleReader(QMainWindow):
         super().closeEvent(event)
 
     def page_navigation(self) -> None:
+        """
+        Opens the comic navigation window and then updates the sequence
+        with the new page, finally it refreshes the display.
+        """
         dialog = Navigation(self.comic.total_pages)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             self.sequence.update_position(int(dialog.text))

--- a/reader.py
+++ b/reader.py
@@ -535,22 +535,7 @@ class PagePreloader(QObject):
         """
         self.loading.discard(index)
         self.image_cache[index] = pixmap
-        page = self.comic.pages[index]
-        if not page.analysed:
-            if pixmap.width() / pixmap.height() > 1.3:
-                page.page_type = PageType.SPREAD
-
-            page.analysed = True
-
-        if not self.wait_for_spread:
-            self.page_ready.emit(index)
-            return
-
-        if self.pending_spread:
-            left, right = self.pending_spread
-            if left in self.image_cache and right in self.image_cache:
-                self.pending_spread = None
-                self.spread_ready.emit(left)
+        self.page_ready.emit(index)
 
     def on_error(self, index: int, message: str):
         """

--- a/reader.py
+++ b/reader.py
@@ -4,26 +4,50 @@ is snappy and responsive.
 """
 
 import logging
+import os
 import zipfile
 from collections import OrderedDict
-from functools import partial
+from dataclasses import dataclass
+from enum import Enum, auto
 from io import BytesIO
+from pathlib import Path
+from typing import overload
 
+from dotenv import load_dotenv
 from PIL import Image
-from PySide6.QtCore import QObject, QRunnable, Qt, QThreadPool, QTimer, Signal
-from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtCore import (
+    QBuffer,
+    QByteArray,
+    QIODevice,
+    QObject,
+    QRunnable,
+    Qt,
+    QThreadPool,
+    Signal,
+)
+from PySide6.QtGui import (
+    QIcon,
+    QImage,
+    QImageReader,
+    QKeySequence,
+    QPainter,
+    QPixmap,
+    QShortcut,
+)
 from PySide6.QtWidgets import (
-    QHBoxLayout,
     QLabel,
     QMainWindow,
     QToolBar,
-    QToolButton,
-    QWidget,
 )
 
 from classes.helper_classes import GUIComicInfo
 from metadata_gui_panel import MetadataDialog
 
+load_dotenv()
+resources_path = os.getenv("FRONTEND_RESOURCES")
+if not resources_path:
+    raise RuntimeError("FRONTEND_RESOURCES environment variable is not set.")
+IMAGES = Path(resources_path)
 logging.basicConfig(
     filename="debug.log",
     level=logging.INFO,
@@ -41,6 +65,32 @@ class PageIndexError(ComicError):
 
 class ImageLoadError(ComicError):
     """Raised when an image fails to load."""
+
+
+class ReadMode(Enum):
+    SINGLE_PAGE = auto()
+    DOUBLE_PAGE = auto()
+
+
+class PageType(Enum):
+    UNKNOWN = auto()
+    COVER = auto()
+    BACK_COVER = auto()
+    NORMAL = auto()
+    SPREAD = auto()
+
+
+@dataclass(slots=True)
+class PageInfo:
+    filename: str
+    index: int
+    page_type: PageType = PageType.UNKNOWN
+    analysed: bool = False
+
+
+@dataclass(slots=True)
+class DisplayPage:
+    pages: tuple[int, ...]
 
 
 class Comic:
@@ -69,12 +119,15 @@ class Comic:
         self.image_names = sorted(
             name
             for name in self.zip.namelist()
-            if name.lower().endswith(
-                (".jpg", ".jpeg", ".png")
-            )  # TODO: Use sort_function.py here.
+            if name.lower().endswith((".jpg", ".jpeg", ".png"))
         )
         if not self.image_names:
             raise ComicError("No images found in the file.")
+        self.pages = [PageInfo(n, pos) for pos, n in enumerate(self.image_names)]
+        self.pages[0].page_type = PageType.COVER
+        self.pages[-1].page_type = PageType.BACK_COVER
+        for i in self.pages:
+            self.analyse_page(i)
         self.total_pages = len(self.image_names)
         self.size = comic_info.filepath.stat().st_size
         self.cache: OrderedDict[str, bytes] = OrderedDict()
@@ -132,6 +185,90 @@ class Comic:
         """
         self.current_index += 1
         return self.get_image_data(self.current_index)
+
+    def image_size(self, index: int) -> tuple[int, int]:
+        page = self.pages[index]
+        image_bytes = self.zip.read(page.filename)
+
+        buffer = QBuffer()
+        buffer.setData(QByteArray(image_bytes))
+        buffer.open(QIODevice.OpenModeFlag.ReadOnly)
+
+        reader = QImageReader(buffer)
+        size = reader.size()
+        return size.width(), size.height()
+
+    def analyse_page(self, page) -> PageInfo:
+        if page.page_type != PageType.UNKNOWN:
+            return page
+
+        width, height = self.image_size(page.index)
+        page.page_type = PageType.SPREAD if width / height > 1.3 else PageType.NORMAL
+        return page
+
+
+class ReadingSequence:
+    def __init__(self, comic: Comic):
+        super().__init__()
+        self.comic = comic
+        self.current_pos = 0
+        self.display_pages: list[DisplayPage] = []
+        self.page_to_position: dict[int, int] = {}
+        i = 0
+        while i < self.comic.total_pages:
+            display = self.build_display_page(i)
+            self.display_pages.append(display)
+            pos = len(self.display_pages) - 1
+            for page in display.pages:
+                self.page_to_position[page] = pos
+
+            if len(display.pages) == 2:
+                i += 2
+            else:
+                i += 1
+
+        self.current_pos = self.index_to_page(comic.current_index)
+
+    def build_display_page(self, index: int) -> DisplayPage:
+        page = self.comic.pages[index]
+
+        if page.page_type in (PageType.COVER, PageType.BACK_COVER):
+            return DisplayPage((index,))
+
+        if page.page_type == PageType.UNKNOWN:
+            raise ValueError(f"Page at position {index} has not been analysed yet.")
+
+        if page.page_type == PageType.SPREAD:
+            return DisplayPage((index,))
+
+        if index == self.comic.total_pages - 1:
+            return DisplayPage((index,))
+
+        next_page = self.comic.pages[index + 1]
+
+        if next_page.page_type in (PageType.BACK_COVER, PageType.SPREAD):
+            return DisplayPage((index,))
+
+        return DisplayPage((index, index + 1))
+
+    def index_to_page(self, index: int) -> int:
+        return self.page_to_position[index]
+
+    def update_position(self, index: int):
+        self.current_pos = self.index_to_page(index)
+
+    def get_index_from_pos(self) -> int:
+        display = self.display_pages[self.current_pos]
+        return display.pages[0]
+
+    def next(self):
+        self.current_pos += 1
+
+    def prev(self):
+        self.current_pos -= 1
+
+    def current_display(self) -> tuple[int, ...]:
+        return self.display_pages[self.current_pos].pages
 
 
 class ImageLoadSignals(QObject):
@@ -302,6 +439,7 @@ class PagePreloader(QObject):
     """
 
     page_ready = Signal(int)
+    spread_ready = Signal(int)
 
     def __init__(self, comic: Comic, buffer: int = 8):
         """
@@ -318,11 +456,13 @@ class PagePreloader(QObject):
 
         self.image_cache: dict[int, QPixmap] = {}
         self.loading: set[int] = set()
+        self.wait_for_spread: bool = False
+        self.pending_spread: tuple[int, int] | None = None
 
         self.pool = QThreadPool()
-        self.pool.setMaxThreadCount(4)
+        self.pool.setMaxThreadCount(5)
 
-    def preload(self, current_index: int):
+    def preload(self, index: int):
         """
         Preload pages surrounding the current reading position.
 
@@ -341,8 +481,9 @@ class PagePreloader(QObject):
             - Cache eviction occurs immediately for pages outside
             the preload window.
         """
-        start = max(0, current_index - self.buffer)
-        end = min(self.comic.total_pages - 1, current_index + self.buffer)
+        start = max(0, index - self.buffer)
+        end = min(self.comic.total_pages - 1, index + self.buffer)
+        self.pending_spread = (index, index + 1) if self.wait_for_spread else None
 
         wanted = set(range(start, end + 1))
 
@@ -394,7 +535,22 @@ class PagePreloader(QObject):
         """
         self.loading.discard(index)
         self.image_cache[index] = pixmap
-        self.page_ready.emit(index)
+        page = self.comic.pages[index]
+        if not page.analysed:
+            if pixmap.width() / pixmap.height() > 1.3:
+                page.page_type = PageType.SPREAD
+
+            page.analysed = True
+
+        if not self.wait_for_spread:
+            self.page_ready.emit(index)
+            return
+
+        if self.pending_spread:
+            left, right = self.pending_spread
+            if left in self.image_cache and right in self.image_cache:
+                self.pending_spread = None
+                self.spread_ready.emit(left)
 
     def on_error(self, index: int, message: str):
         """
@@ -447,55 +603,63 @@ class SimpleReader(QMainWindow):
         super().__init__()
 
         self.comic = comic
+        self.sequence = ReadingSequence(self.comic)
         self.current_index: int = comic.current_index
+        self.read_mode = ReadMode.SINGLE_PAGE  # default reading mode
 
         self.preloader = PagePreloader(self.comic, buffer=8)
         self.preloader.page_ready.connect(self.on_page_ready)
+        self.preloader.spread_ready.connect(self.on_page_ready)
 
         self.setWindowTitle("Comic Reader")
 
         self.image_label = QLabel("Loading...", alignment=Qt.AlignmentFlag.AlignCenter)
-        self.page_label = QLabel("Page 1", alignment=Qt.AlignmentFlag.AlignCenter)
-        # TODO: This needs to be dynamic so that the page number changes
-        self.menu_bar_widget = QWidget()
-        self.menu_bar_layout = QHBoxLayout()
-        self.menu_bar_widget.setLayout(self.menu_bar_layout)
-        self.setMenuWidget(self.menu_bar_widget)
+        self.page_label = QLabel(
+            f"Page {comic.current_index}", alignment=Qt.AlignmentFlag.AlignCenter
+        )
 
-        self.add_menu_button("Navigation Toolbar", self.show_navigation_toolbar)
-        self.add_menu_button("Comments Toolbar", self.show_comments_toolbar)
-        self.add_menu_button("Metadata", self.open_metadata_panel)
-        # self.add_menu_button("Settings", self.open_settings_panel)
-        # self.add_menu_button("Help", self.open_help_panel)
+        self.toolbar = QToolBar("Navigation Tools")
+        self.prev_action = self.toolbar.addAction(
+            QIcon(str(IMAGES / "arrow_left.svg")), "", self.prev_page
+        )
+        self.prev_action.setToolTip("Previous Page")
+        self.next_action = self.toolbar.addAction(
+            QIcon(str(IMAGES / "arrow_right.svg")), "", self.next_page
+        )
+        self.next_action.setToolTip("Next Page")
+        self.toolbar.addAction(QIcon(str(IMAGES / "zoom_in.svg")), "")
+        self.toolbar.addAction(QIcon(str(IMAGES / "zoom_out.svg")), "")
+        self.toolbar.addAction(QIcon(str(IMAGES / "bookmark_add.svg")), "")
+        self.toolbar.addAction(QIcon(str(IMAGES / "comment_add.svg")), "")
+        self.toolbar.addAction(
+            QIcon(str(IMAGES / "one_page.svg")), "", self.set_one_page
+        )
+        self.toolbar.addAction(
+            QIcon(str(IMAGES / "two_pages.svg")), "", self.set_double_page
+        )
+        self.analytics_action = self.toolbar.addAction(
+            QIcon(str(IMAGES / "analytics.svg")), "", self.open_metadata_panel
+        )
+        self.analytics_action.setToolTip("Open Metadata Panel")
 
-        self.menu_bar_widget.hide()
-        self.hide_menu_timer = QTimer()
-        self.hide_menu_timer.setSingleShot(True)
-        self.hide_menu_timer.timeout.connect(self.menu_bar_widget.hide)
+        self.addToolBar(Qt.ToolBarArea.LeftToolBarArea, self.toolbar)
 
-        self.setMouseTracking(True)
-
-        self.navigation_toolbar = QToolBar("Navigation Tools")
-        self.navigation_toolbar.addAction("Zoom In")
-        self.navigation_toolbar.addAction("Zoom Out")
-        self.navigation_toolbar.addAction("Prev Page", self.prev_page)
-        self.navigation_toolbar.addAction("Next Page", self.next_page)
-
-        self.comments_toolbar = QToolBar("Commenting Tools")
-        self.comments_toolbar.addAction("Add Bookmark")
-        self.comments_toolbar.addAction("Add Comment")
-
-        self.addToolBar(self.navigation_toolbar)
-        self.addToolBar(self.comments_toolbar)
-
-        self.navigation_toolbar.show()
-        self.comments_toolbar.hide()
-        self.current_toolbar = self.navigation_toolbar
+        self.toolbar.show()
 
         self.image_label.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
         self.setCentralWidget(self.image_label)
 
+        self.shortcut = QShortcut(QKeySequence("F11"), self)
+        self.shortcut.activated.connect(self.toggle_fullscreen)
+
         self.display_current_page()
+
+    def toggle_fullscreen(self) -> None:
+        if self.isFullScreen():
+            self.showMaximized()
+        else:
+            self.showFullScreen()
 
     def display_current_page(self) -> None:
         """
@@ -505,24 +669,48 @@ class SimpleReader(QMainWindow):
         a blank grey image with 'Loading...' is displayed and a
         task is scheduled which displays the image once completed.
         """
-        index = self.current_index
-        logging.info(f"Changed page index to {index}")
-        if index in self.preloader.image_cache:
+        if self.read_mode == ReadMode.SINGLE_PAGE:
+            if self.current_index in self.preloader.image_cache:
+                self.render_pixmap(
+                    self.current_index, self.preloader.image_cache[self.current_index]
+                )
+            else:
+                self.image_label.setText("Loading...")
+                self.preloader.preload(self.current_index)
+            return
+
+        display = self.sequence.current_display()
+        if len(display) == 1:
+            index = display[0]
+            logging.info(f"Changed page index to {index}")
+            if index not in self.preloader.image_cache:
+                self.image_label.setText("Loading...")
+                self.preloader.preload(index)
+                return
             self.render_pixmap(index, self.preloader.image_cache[index])
+
         else:
-            self.image_label.setText("Loading...")
-            self.preloader.preload(index)
+            left, right = display
+            if (
+                left in self.preloader.image_cache
+                and right in self.preloader.image_cache
+            ):
+                left_img = self.preloader.image_cache[left]
+                right_img = self.preloader.image_cache[right]
+                self.render_pixmap(left, (left_img, right_img))
+            else:
+                self.image_label.setText("Loading...")
+                self.preloader.preload(left)
 
-        # scaled = pixmap.scaledToHeight(
-        #     self.image_label.height(), Qt.SmoothTransformation
-        # )
-        # self.image_label.setPixmap(scaled)
-        # self.page_label.setText(f"Page {index + 1} / {self.comic.total_pages}")
+    @overload
+    def render_pixmap(self, index: int, pixmap: QPixmap) -> None: ...
 
-        # if index + 1 < self.comic.total_pages:
-        #     self.preload_page(index + 1)
+    @overload
+    def render_pixmap(self, index: int, pixmap: tuple[QPixmap, QPixmap]) -> None: ...
 
-    def render_pixmap(self, index: int, pixmap: QPixmap) -> None:
+    def render_pixmap(
+        self, index: int, pixmap: QPixmap | tuple[QPixmap, QPixmap]
+    ) -> None:
         """
         Scales the pixmap taken from the image file into the right size and then
         displays it, finally updates the displayed page number.
@@ -531,13 +719,27 @@ class SimpleReader(QMainWindow):
             index (int): The zero-indexed index of the page to scale and load around.
             pixmap (QPixmap): The QPixmap of the image to be displayed.
         """
-        scaled = pixmap.scaledToHeight(
+        if isinstance(pixmap, QPixmap):
+            final = pixmap
+        else:
+            left, right = pixmap
+
+            width = left.width() + right.width()
+            height = max(left.height(), right.height())
+
+            final = QPixmap(width, height)
+            final.fill(Qt.GlobalColor.transparent)
+
+            painter = QPainter(final)
+            painter.drawPixmap(0, 0, left)
+            painter.drawPixmap(left.width(), 0, right)
+            painter.end()
+
+        scaled = final.scaledToHeight(
             self.image_label.height(), Qt.TransformationMode.SmoothTransformation
         )
         self.image_label.setPixmap(scaled)
         self.page_label.setText(f"Page {index + 1} / {self.comic.total_pages}")
-
-        self.preloader.preload(index)
 
     def on_page_ready(self, index: int):
         """
@@ -549,54 +751,22 @@ class SimpleReader(QMainWindow):
         Args:
             index (int): The index of the page just loaded by the preloader.
         """
-        if index == self.current_index:
-            pixmap = self.preloader.image_cache.get(index)
-            if pixmap:
-                self.render_pixmap(index, pixmap)
-
-    def add_menu_button(self, name: str, callback, *args):
-        """
-        A reuseable function to add buttons into the menu.
-
-        Args:
-            name (str): The text to display on the button.
-            callback (function): The function to call when the button
-                is clicked.
-        """
-        button = QToolButton()
-        button.setText(name)
-        button.setAutoRaise(True)
-        button.clicked.connect(partial(callback, *args))
-        self.menu_bar_layout.addWidget(button)
-
-    def switch_toolbar(self, toolbar: QToolBar):
-        """
-        Reuseable function for switching to a certain toolbar.
-
-        Args:
-            toolbar (QToolBar): The toolbar to display.
-        """
-        if self.current_toolbar == toolbar:
+        if self.read_mode == ReadMode.SINGLE_PAGE:
+            if index == self.current_index:
+                self.display_current_page()
             return
-        self.current_toolbar.hide()
-        toolbar.show()
-        self.current_toolbar = toolbar
 
-    def show_navigation_toolbar(self):
-        """Switches to the navigation toolbar."""
-        self.switch_toolbar(self.navigation_toolbar)
-
-    def show_comments_toolbar(self):
-        """Switches to the commenting toolbar."""
-        self.switch_toolbar(self.comments_toolbar)
+        display = self.sequence.current_display()
+        if index in display:
+            self.display_current_page()
 
     def open_metadata_panel(self):
         """Opens the expanded metadata panel for the comic."""
         self.metadata_popup = MetadataDialog(self.comic.info)
         self.metadata_popup.show()
 
-    # def resizeEvent(self, event):
-    #     self.preload_page(self.current_index)
+    def update_index(self):
+        self.current_index = self.sequence.get_index_from_pos()
 
     def next_page(self):
         """
@@ -605,10 +775,13 @@ class SimpleReader(QMainWindow):
         Increases the `self.current_index` by 1 and then calls the function to display
         the current page.
         """
-        if self.current_index + 1 < self.comic.total_pages:
-            self.current_index += 1
+        if self.read_mode == ReadMode.SINGLE_PAGE:
+            if self.current_index + 1 < self.comic.total_pages:
+                self.current_index += 1
+                self.display_current_page()
+        else:
+            self.sequence.next()
             self.display_current_page()
-            self.page_changed.emit(self.comic.id, self.current_index)
 
     def prev_page(self):
         """
@@ -617,10 +790,13 @@ class SimpleReader(QMainWindow):
         Decreases the `self.current_index` by 1 and then calls the function to display
         the current page.
         """
-        if self.current_index > 0:
-            self.current_index -= 1
+        if self.read_mode == ReadMode.SINGLE_PAGE:
+            if self.current_index > 0:
+                self.current_index -= 1
+                self.display_current_page()
+        else:
+            self.sequence.prev()
             self.display_current_page()
-            self.page_changed.emit(self.comic.id, self.current_index)
 
     def keyPressEvent(self, event):
         """
@@ -633,26 +809,17 @@ class SimpleReader(QMainWindow):
         elif key == Qt.Key.Key_Left:
             self.prev_page()
 
-    def mouseMoveEvent(self, event):
-        """
-        Listens for mouse movements while reading. If the mouse is moved near the very
-        top then a dropdown menu pops up with options for changing the toolbar or
-        opening the metadata panel.
+    def set_one_page(self) -> None:
+        self.read_mode = ReadMode.SINGLE_PAGE
+        self.preloader.wait_for_spread = False
+        self.update_index()
+        self.display_current_page()
 
-        The dropdown menu is only displayed for a certain amount of time and then is
-        hidden again to conserve reading space.
-        """
-        mouse_y = event.position().y()
-
-        if mouse_y <= 40:
-            if not self.menu_bar_widget.isVisible():
-                self.menu_bar_widget.show()
-            self.hide_menu_timer.stop()
-
-        else:
-            if self.menu_bar_widget.isVisible() and not self.hide_menu_timer.isActive():
-                self.hide_menu_timer.start(1500)
-        super().mouseMoveEvent(event)
+    def set_double_page(self) -> None:
+        self.read_mode = ReadMode.DOUBLE_PAGE
+        self.preloader.wait_for_spread = True
+        self.sequence.update_position(self.current_index)
+        self.display_current_page()
 
     def closeEvent(self, event) -> None:
         """

--- a/reader.py
+++ b/reader.py
@@ -75,6 +75,8 @@ class ImageLoadError(ComicError):
 class ReadMode(Enum):
     SINGLE_PAGE = auto()
     DOUBLE_PAGE = auto()
+    MANGA = auto()
+    INFINITY = auto()
 
 
 class PageType(Enum):
@@ -213,16 +215,47 @@ class Comic:
 
 class ReadingSequence:
     def __init__(self, comic: Comic):
-        super().__init__()
         self.comic = comic
-        self.current_pos = 0
+        self.mode = ReadMode.SINGLE_PAGE
+        self.position = 0
+
         self.display_pages: list[DisplayPage] = []
         self.page_to_position: dict[int, int] = {}
+
+        self.build_sequence()
+        self.position = self.archive_index_to_position(comic.current_index)
+
+    def set_mode(self, mode: ReadMode):
+        current_archive_page = self.current_display()[0]
+
+        self.mode = mode
+        self.build_sequence()
+
+        self.position = self.archive_index_to_position(current_archive_page)
+
+    def build_sequence(self):
+        self.page_to_position.clear()
+        match self.mode:
+            case ReadMode.SINGLE_PAGE:
+                self.display_pages = self.build_single()
+
+            case ReadMode.DOUBLE_PAGE:
+                self.display_pages = self.build_double()
+
+            case ReadMode.MANGA:
+                self.display_pages = self.build_manga()
+
+        for pos, display in enumerate(self.display_pages):
+            for page in display.pages:
+                self.page_to_position[page] = pos
+
+    def build_double(self) -> list[DisplayPage]:
+        pages = []
         i = 0
         while i < self.comic.total_pages:
             display = self.build_display_page(i)
-            self.display_pages.append(display)
-            pos = len(self.display_pages) - 1
+            pages.append(display)
+            pos = len(pages) - 1
             for page in display.pages:
                 self.page_to_position[page] = pos
 
@@ -231,7 +264,13 @@ class ReadingSequence:
             else:
                 i += 1
 
-        self.current_pos = self.index_to_page(comic.current_index)
+        return pages
+
+    def build_single(self) -> list[DisplayPage]:
+        return [DisplayPage((page.index,)) for page in self.comic.pages]
+
+    def build_manga(self) -> list[DisplayPage]:
+        return list(reversed(self.build_single()))
 
     def build_display_page(self, index: int) -> DisplayPage:
         page = self.comic.pages[index]
@@ -255,24 +294,24 @@ class ReadingSequence:
 
         return DisplayPage((index, index + 1))
 
-    def index_to_page(self, index: int) -> int:
+    def archive_index_to_position(self, index: int) -> int:
         return self.page_to_position[index]
 
     def update_position(self, index: int):
-        self.current_pos = self.index_to_page(index)
+        self.position = self.archive_index_to_position(index)
 
-    def get_index_from_pos(self) -> int:
-        display = self.display_pages[self.current_pos]
+    def position_to_archive_index(self) -> int:
+        display = self.display_pages[self.position]
         return display.pages[0]
 
     def next(self):
-        self.current_pos += 1
+        self.position += 1
 
     def prev(self):
-        self.current_pos -= 1
+        self.position -= 1
 
     def current_display(self) -> tuple[int, ...]:
-        return self.display_pages[self.current_pos].pages
+        return self.display_pages[self.position].pages
 
 
 class ImageLoadSignals(QObject):
@@ -376,7 +415,6 @@ class ImageLoadTask(QRunnable):
         """
         try:
             data = self.comic.get_image_data(self.index)
-
             image = Image.open(BytesIO(data))
             image.load()
             image = image.convert("RGBA")
@@ -445,7 +483,7 @@ class PagePreloader(QObject):
     page_ready = Signal(int)
     spread_ready = Signal(int)
 
-    def __init__(self, comic: Comic, buffer: int = 8):
+    def __init__(self, comic: Comic):
         """
         Intialise the page preloader.
 
@@ -456,17 +494,34 @@ class PagePreloader(QObject):
         """
         super().__init__()
         self.comic = comic
-        self.buffer = buffer
+
+        self.forward_buff = 16
+        self.backward_buff = 4
 
         self.image_cache: dict[int, QPixmap] = {}
         self.loading: set[int] = set()
         self.wait_for_spread: bool = False
-        self.pending_spread: tuple[int, int] | None = None
 
         self.pool = QThreadPool()
-        self.pool.setMaxThreadCount(5)
+        self.pool.setMaxThreadCount(6)
 
-    def preload(self, index: int):
+    def get_load_order(self, index: int) -> list[int]:
+        pages = []
+        pages.append(index)
+
+        for offset in range(1, self.forward_buff + 1):
+            page = index + offset
+            if page < self.comic.total_pages:
+                pages.append(page)
+
+        for offset in range(1, self.backward_buff + 1):
+            page = index - offset
+            if page >= 0:
+                pages.append(page)
+
+        return pages
+
+    def preload(self, index: int) -> None:
         """
         Preload pages surrounding the current reading position.
 
@@ -485,22 +540,20 @@ class PagePreloader(QObject):
             - Cache eviction occurs immediately for pages outside
             the preload window.
         """
-        start = max(0, index - self.buffer)
-        end = min(self.comic.total_pages - 1, index + self.buffer)
-        self.pending_spread = (index, index + 1) if self.wait_for_spread else None
+        load_order = self.get_load_order(index)
 
-        wanted = set(range(start, end + 1))
+        wanted = set(load_order)
 
         for idx in list(self.image_cache):
             if idx not in wanted:
                 del self.image_cache[idx]
 
-        for idx in wanted:
+        for priority, idx in enumerate(reversed(load_order)):
             if idx in self.image_cache or idx in self.loading:
                 continue
-            self.schedule_load(idx)
+            self.schedule_load(idx, priority)
 
-    def schedule_load(self, index: int):
+    def schedule_load(self, index: int, priority: int = 0):
         """
         Schedule asynchronous loading of a page image.
 
@@ -520,7 +573,7 @@ class PagePreloader(QObject):
         task.signals.finished.connect(self.on_loaded)
         task.signals.error.connect(self.on_error)
 
-        self.pool.start(task)
+        self.pool.start(task, priority)
 
     def on_loaded(self, index: int, pixmap: QPixmap):
         """
@@ -615,11 +668,9 @@ class SimpleReader(QMainWindow):
         super().__init__()
 
         self.comic = comic
-        self.sequence = ReadingSequence(self.comic)
-        self.current_index: int = comic.current_index
-        self.read_mode = ReadMode.SINGLE_PAGE  # default reading mode
+        self.sequence = ReadingSequence(comic)
 
-        self.preloader = PagePreloader(self.comic, buffer=8)
+        self.preloader = PagePreloader(comic)
         self.preloader.page_ready.connect(self.on_page_ready)
         self.preloader.spread_ready.connect(self.on_page_ready)
 
@@ -684,48 +735,32 @@ class SimpleReader(QMainWindow):
         a blank grey image with 'Loading...' is displayed and a
         task is scheduled which displays the image once completed.
         """
-        if self.read_mode == ReadMode.SINGLE_PAGE:
-            if self.current_index in self.preloader.image_cache:
-                self.render_pixmap(
-                    self.current_index, self.preloader.image_cache[self.current_index]
-                )
-            else:
-                self.image_label.setText("Loading...")
-                self.preloader.preload(self.current_index)
-            return
-
         display = self.sequence.current_display()
+        failed = False
+        for page_index in display:
+            if page_index not in self.preloader.image_cache:
+                self.image_label.setText("Loading...")
+                self.preloader.preload(page_index)
+                failed = True
+        if failed:
+            return
         if len(display) == 1:
-            index = display[0]
-            logging.info(f"Changed page index to {index}")
-            if index not in self.preloader.image_cache:
-                self.image_label.setText("Loading...")
-                self.preloader.preload(index)
-                return
-            self.render_pixmap(index, self.preloader.image_cache[index])
-
+            self.render_pixmap(self.preloader.image_cache[display[0]])
         else:
-            left, right = display
-            if (
-                left in self.preloader.image_cache
-                and right in self.preloader.image_cache
-            ):
-                left_img = self.preloader.image_cache[left]
-                right_img = self.preloader.image_cache[right]
-                self.render_pixmap(left, (left_img, right_img))
-            else:
-                self.image_label.setText("Loading...")
-                self.preloader.preload(left)
+            self.render_pixmap(
+                (
+                    self.preloader.image_cache[display[0]],
+                    self.preloader.image_cache[display[1]],
+                )
+            )
 
     @overload
-    def render_pixmap(self, index: int, pixmap: QPixmap) -> None: ...
+    def render_pixmap(self, pixmap: QPixmap) -> None: ...
 
     @overload
-    def render_pixmap(self, index: int, pixmap: tuple[QPixmap, QPixmap]) -> None: ...
+    def render_pixmap(self, pixmap: tuple[QPixmap, QPixmap]) -> None: ...
 
-    def render_pixmap(
-        self, index: int, pixmap: QPixmap | tuple[QPixmap, QPixmap]
-    ) -> None:
+    def render_pixmap(self, pixmap: QPixmap | tuple[QPixmap, QPixmap]) -> None:
         """
         Scales the pixmap taken from the image file into the right size and then
         displays it, finally updates the displayed page number.
@@ -754,7 +789,7 @@ class SimpleReader(QMainWindow):
             self.image_label.height(), Qt.TransformationMode.SmoothTransformation
         )
         self.image_label.setPixmap(scaled)
-        self.page_label.setText(f"Page {index + 1} / {self.comic.total_pages}")
+        # self.page_label.setText(f"Page {index + 1} / {self.comic.total_pages}")
 
     def on_page_ready(self, index: int):
         """
@@ -766,11 +801,6 @@ class SimpleReader(QMainWindow):
         Args:
             index (int): The index of the page just loaded by the preloader.
         """
-        if self.read_mode == ReadMode.SINGLE_PAGE:
-            if index == self.current_index:
-                self.display_current_page()
-            return
-
         display = self.sequence.current_display()
         if index in display:
             self.display_current_page()
@@ -780,9 +810,6 @@ class SimpleReader(QMainWindow):
         self.metadata_popup = MetadataDialog(self.comic.info)
         self.metadata_popup.show()
 
-    def update_index(self):
-        self.current_index = self.sequence.get_index_from_pos()
-
     def next_page(self):
         """
         Moves the reader to the next page.
@@ -790,13 +817,8 @@ class SimpleReader(QMainWindow):
         Increases the `self.current_index` by 1 and then calls the function to display
         the current page.
         """
-        if self.read_mode == ReadMode.SINGLE_PAGE:
-            if self.current_index + 1 < self.comic.total_pages:
-                self.current_index += 1
-                self.display_current_page()
-        else:
-            self.sequence.next()
-            self.display_current_page()
+        self.sequence.next()
+        self.display_current_page()
 
     def prev_page(self):
         """
@@ -805,13 +827,8 @@ class SimpleReader(QMainWindow):
         Decreases the `self.current_index` by 1 and then calls the function to display
         the current page.
         """
-        if self.read_mode == ReadMode.SINGLE_PAGE:
-            if self.current_index > 0:
-                self.current_index -= 1
-                self.display_current_page()
-        else:
-            self.sequence.prev()
-            self.display_current_page()
+        self.sequence.prev()
+        self.display_current_page()
 
     def keyPressEvent(self, event):
         """
@@ -834,15 +851,11 @@ class SimpleReader(QMainWindow):
             return
 
     def set_one_page(self) -> None:
-        self.read_mode = ReadMode.SINGLE_PAGE
-        self.preloader.wait_for_spread = False
-        self.update_index()
+        self.sequence.set_mode(ReadMode.SINGLE_PAGE)
         self.display_current_page()
 
     def set_double_page(self) -> None:
-        self.read_mode = ReadMode.DOUBLE_PAGE
-        self.preloader.wait_for_spread = True
-        self.sequence.update_position(self.current_index)
+        self.sequence.set_mode(ReadMode.DOUBLE_PAGE)
         self.display_current_page()
 
     def closeEvent(self, event) -> None:
@@ -852,15 +865,13 @@ class SimpleReader(QMainWindow):
         This is used by the reading controller for memory and resource
         management.
         """
-        self.update_index()
-        self.closed.emit(self.comic.id, self.current_index)
+        self.closed.emit(self.comic.id, self.sequence.position_to_archive_index())
         super().closeEvent(event)
 
     def page_navigation(self) -> None:
         dialog = Navigation(self.comic.total_pages)
         if dialog.exec() == QDialog.DialogCode.Accepted:
-            self.current_index = int(dialog.text)
-            self.sequence.update_position(self.current_index)
+            self.sequence.update_position(int(dialog.text))
             self.display_current_page()
         else:
             return

--- a/reader_controller.py
+++ b/reader_controller.py
@@ -42,7 +42,7 @@ class ReadingController:
         comic = Comic(comic_data, val if val is not None else 0)
         comic_reader = SimpleReader(comic)
         comic_reader.closed.connect(self.window_shutdown)
-        comic_reader.showMaximized()
+        comic_reader.showFullScreen()
 
         self.open_windows[comic_data.primary_id] = comic_reader
 

--- a/reader_controller.py
+++ b/reader_controller.py
@@ -60,7 +60,7 @@ class ReadingController:
         try:
             with RepoWorker() as saver:
                 if page == 0:
-                    pass
+                    saver.remove_from_reading_progress(primary_id)
                 elif page >= reader.comic.total_pages - 1:
                     saver.mark_as_finished(primary_id, page)
                 else:


### PR DESCRIPTION
Add option to read pages in double-page mode. This improvement required a dedicated class for tracking the sequence of pages in the comic archive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single-page, double-page, and manga-style reading modes with automatic cover/back-cover and spread behavior.
  * Improved performance by preloading pages ahead/behind the current view and re-rendering only when relevant.
  * Enhanced navigation with mouse-wheel paging, one/two-page mode switching, and a page-jump dialog.
  * Reader now opens in full-screen when a comic is opened.
* **Bug Fixes**
  * Improved page classification and ensure the displayed page(s) stay consistent with loaded content.
  * When exiting at the beginning of a comic, saved reading progress is cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->